### PR TITLE
Strip NLP out, upgrade core engine, upgrade DistillNET

### DIFF
--- a/Citadel.Core.Windows/Properties/AssemblyInfo.cs
+++ b/Citadel.Core.Windows/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.6.16.0")]
-[assembly: AssemblyFileVersion("1.6.16.0")]
+[assembly: AssemblyVersion("1.6.17.0")]
+[assembly: AssemblyFileVersion("1.6.17.0")]

--- a/Citadel.IPC.Common/Properties/AssemblyInfo.cs
+++ b/Citadel.IPC.Common/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.6.16.0")]
-[assembly: AssemblyFileVersion("1.6.16.0")]
+[assembly: AssemblyVersion("1.6.17.0")]
+[assembly: AssemblyFileVersion("1.6.17.0")]

--- a/CitadelGUI/Properties/AssemblyInfo.cs
+++ b/CitadelGUI/Properties/AssemblyInfo.cs
@@ -49,5 +49,5 @@ using System.Windows;
 //
 // You can specify all the values or you can default the Build and Revision Numbers by using the '*'
 // as shown below: [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.6.16.0")]
-[assembly: AssemblyFileVersion("1.6.16.0")]
+[assembly: AssemblyVersion("1.6.17.0")]
+[assembly: AssemblyFileVersion("1.6.17.0")]

--- a/CitadelService/CitadelService x64.csproj
+++ b/CitadelService/CitadelService x64.csproj
@@ -91,13 +91,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="CitadelCore.Windows">
-      <Version>1.3.3</Version>
-    </PackageReference>
-    <PackageReference Include="Com.TechnikEmpire.ApacheOpenNLP">
-      <Version>1.7.2</Version>
+      <Version>1.3.4</Version>
     </PackageReference>
     <PackageReference Include="DistillNET">
-      <Version>1.4.4</Version>
+      <Version>1.4.5</Version>
     </PackageReference>
     <PackageReference Include="DNS">
       <Version>2.1.0</Version>

--- a/CitadelService/CitadelService x86.csproj
+++ b/CitadelService/CitadelService x86.csproj
@@ -32,12 +32,6 @@
     <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="CitadelCore">
-      <HintPath>..\dependencies\CitadelCore.dll</HintPath>
-    </Reference>
-    <Reference Include="CitadelCore.Windows">
-      <HintPath>..\dependencies\CitadelCore.Windows.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
@@ -96,17 +90,11 @@
     <EmbeddedResource Include="Resources\UserLicense.txt" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="CitadelCore">
-      <Version>1.3.8</Version>
-    </PackageReference>
     <PackageReference Include="CitadelCore.Windows">
-      <Version>1.3.3</Version>
-    </PackageReference>
-    <PackageReference Include="Com.TechnikEmpire.ApacheOpenNLP">
-      <Version>1.7.2</Version>
+      <Version>1.3.4</Version>
     </PackageReference>
     <PackageReference Include="DistillNET">
-      <Version>1.4.4</Version>
+      <Version>1.4.5</Version>
     </PackageReference>
     <PackageReference Include="DNS">
       <Version>2.1.0</Version>

--- a/CitadelService/Data/Models/CategoryMappedDocumentCategorizerModel.cs
+++ b/CitadelService/Data/Models/CategoryMappedDocumentCategorizerModel.cs
@@ -1,5 +1,4 @@
-﻿using opennlp.tools.doccat;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -8,6 +7,7 @@ using System.Diagnostics;
 
 namespace CitadelService.Data.Models
 {
+#if WITH_NLP
     internal class CategoryMappedDocumentCategorizerModel
     {
         public class ClassificationResult
@@ -100,4 +100,5 @@ namespace CitadelService.Data.Models
             return new ClassificationResult(MappedCategories[internalBestCat], classResult.Max());
         }
     }
+#endif
 }

--- a/CitadelService/Properties/AssemblyInfo.cs
+++ b/CitadelService/Properties/AssemblyInfo.cs
@@ -33,5 +33,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers by using the '*'
 // as shown below: [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyVersion("1.6.16.0")]
-[assembly: AssemblyFileVersion("1.6.16.0")]
+[assembly: AssemblyVersion("1.6.17.0")]
+[assembly: AssemblyFileVersion("1.6.17.0")]

--- a/CitadelService/Services/FilterServiceProvider.cs
+++ b/CitadelService/Services/FilterServiceProvider.cs
@@ -24,7 +24,6 @@ using Microsoft.Win32;
 using murrayju.ProcessExtensions;
 using Newtonsoft.Json;
 using NLog;
-using opennlp.tools.doccat;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -35,7 +34,6 @@ using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
-using System.Management;
 using System.Net;
 using System.Net.NetworkInformation;
 using System.Reflection;
@@ -171,7 +169,9 @@ namespace CitadelService.Services
         /// </summary>
         private ReaderWriterLockSlim m_doccatSlimLock = new ReaderWriterLockSlim();
 
+#if WITH_NLP
         private List<CategoryMappedDocumentCategorizerModel> m_documentClassifiers = new List<CategoryMappedDocumentCategorizerModel>();
+#endif
 
         private ProxyServer m_filteringEngine;
 
@@ -194,7 +194,7 @@ namespace CitadelService.Services
         /// </summary>
         private ConcurrentDictionary<string, MappedFilterListCategoryModel> m_generatedCategoriesMap = new ConcurrentDictionary<string, MappedFilterListCategoryModel>(StringComparer.OrdinalIgnoreCase);
 
-        #endregion FilteringEngineVars
+#endregion FilteringEngineVars
 
         private ReaderWriterLockSlim m_filteringRwLock = new ReaderWriterLockSlim();
 
@@ -1045,6 +1045,7 @@ namespace CitadelService.Services
             }
         }
 
+#if WITH_NLP
         /// <summary>
         /// Loads the given NLP model and list of categories from within the model that we'll
         /// consider enabled. That is to say, any classification result that yeilds a category found
@@ -1118,6 +1119,7 @@ namespace CitadelService.Services
                 m_doccatSlimLock.ExitWriteLock();
             }
         }
+#endif
 
         /// <summary>
         /// Runs initialization off the UI thread. 
@@ -2027,6 +2029,7 @@ namespace CitadelService.Services
                 m_filteringRwLock.ExitReadLock();
             }
 
+#if WITH_NLP
             try
             {
                 m_doccatSlimLock.EnterReadLock();
@@ -2122,6 +2125,7 @@ namespace CitadelService.Services
                 m_doccatSlimLock.ExitReadLock();
             }
 
+#endif
             // Default to zero. Means don't block this content.
             blockedBecause = BlockType.OtherContentClassification;
             return 0;
@@ -2433,6 +2437,7 @@ namespace CitadelService.Services
                             // Now clear all generated categories. These will be re-generated as needed.
                             m_generatedCategoriesMap.Clear();
 
+#if WITH_NLP
                             // Now drop all existing NLP models.
                             try
                             {
@@ -2458,6 +2463,7 @@ namespace CitadelService.Services
                                     }
                                 }
                             }
+#endif
 
                             uint totalFilterRulesLoaded = 0;
                             uint totalFilterRulesFailed = 0;

--- a/Installers/Setup x64/Setup x64.vdproj
+++ b/Installers/Setup x64/Setup x64.vdproj
@@ -317,7 +317,7 @@
             {
             "AssemblyRegister" = "3:1"
             "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:CloudVeil, Version=1.6.15.0, Culture=neutral, processorArchitecture=AMD64"
+            "AssemblyAsmDisplayName" = "8:CloudVeil, Version=1.6.17.0, Culture=neutral, processorArchitecture=AMD64"
                 "ScatterAssemblies"
                 {
                     "_F4B66C76261A43028EC13AABA25DA095"
@@ -400,15 +400,15 @@
         {
         "Name" = "8:Microsoft Visual Studio"
         "ProductName" = "8:CloudVeil For Windows"
-        "ProductCode" = "8:{4F849275-5A6F-4660-90D2-FD9BD5F8A0ED}"
-        "PackageCode" = "8:{3CA689F4-908F-440B-9BA8-1AE4FB9C0771}"
+        "ProductCode" = "8:{D3578CE8-52A1-4CA0-9259-D3B263ED056C}"
+        "PackageCode" = "8:{605FC0B7-0C0F-489C-A103-D57764B44CF4}"
         "UpgradeCode" = "8:{57058EEC-162C-4D48-993E-4AE6095F66CA}"
         "AspNetVersion" = "8:4.0.30319.0"
         "RestartWWWService" = "11:FALSE"
         "RemovePreviousVersions" = "11:TRUE"
         "DetectNewerInstalledVersion" = "11:TRUE"
         "InstallAllUsers" = "11:TRUE"
-        "ProductVersion" = "8:1.6.16"
+        "ProductVersion" = "8:1.6.17"
         "Manufacturer" = "8:CloudVeil"
         "ARPHELPTELEPHONE" = "8:"
         "ARPHELPLINK" = "8:https://cloudveil.org"
@@ -1013,20 +1013,6 @@
                     "ParentName" = "8:_BE7C8A748AB042DFB3B17E4D4E332955.0862028596DF4668AB1D736D2B40424F"
                     "UsePlugInResources" = "11:FALSE"
                     }
-                    "_025B04C0D45EA6BCD41E776F7EB40617.0862028596DF4668AB1D736D2B40424F"
-                    {
-                    "Name" = "8:_025B04C0D45EA6BCD41E776F7EB40617.0862028596DF4668AB1D736D2B40424F"
-                    "DisplayName" = "8:"
-                    "Description" = "8:"
-                    "Type" = "3:2"
-                    "ContextData" = "8:InstallToGAC=;IsolateToManifest=_C2B6ECF719F84B17BE42A75B4AFC85FC.0862028596DF4668AB1D736D2B40424F"
-                    "Attributes" = "3:0"
-                    "Setting" = "3:2"
-                    "Value" = "8:_C2B6ECF719F84B17BE42A75B4AFC85FC.0862028596DF4668AB1D736D2B40424F"
-                    "DefaultValue" = "8:_C2B6ECF719F84B17BE42A75B4AFC85FC.0862028596DF4668AB1D736D2B40424F"
-                    "ParentName" = "8:_BE7C8A748AB042DFB3B17E4D4E332955.0862028596DF4668AB1D736D2B40424F"
-                    "UsePlugInResources" = "11:FALSE"
-                    }
                     "_0290AE3210F3055176BBF7FC19503DA4.0862028596DF4668AB1D736D2B40424F"
                     {
                     "Name" = "8:_0290AE3210F3055176BBF7FC19503DA4.0862028596DF4668AB1D736D2B40424F"
@@ -1122,20 +1108,6 @@
                     "Setting" = "3:2"
                     "Value" = "8:_D97424EAC15B49D78EFB934A22725EE6.0862028596DF4668AB1D736D2B40424F"
                     "DefaultValue" = "8:_D97424EAC15B49D78EFB934A22725EE6.0862028596DF4668AB1D736D2B40424F"
-                    "ParentName" = "8:_BE7C8A748AB042DFB3B17E4D4E332955.0862028596DF4668AB1D736D2B40424F"
-                    "UsePlugInResources" = "11:FALSE"
-                    }
-                    "_0DFD7F42B82648D0B8D1D6C16AE356FA.0862028596DF4668AB1D736D2B40424F"
-                    {
-                    "Name" = "8:_0DFD7F42B82648D0B8D1D6C16AE356FA.0862028596DF4668AB1D736D2B40424F"
-                    "DisplayName" = "8:"
-                    "Description" = "8:"
-                    "Type" = "3:2"
-                    "ContextData" = "8:InstallToGAC=;IsolateToManifest=_D8510077E8014D0B95EABA90EA8C06A0.0862028596DF4668AB1D736D2B40424F"
-                    "Attributes" = "3:0"
-                    "Setting" = "3:2"
-                    "Value" = "8:_D8510077E8014D0B95EABA90EA8C06A0.0862028596DF4668AB1D736D2B40424F"
-                    "DefaultValue" = "8:_D8510077E8014D0B95EABA90EA8C06A0.0862028596DF4668AB1D736D2B40424F"
                     "ParentName" = "8:_BE7C8A748AB042DFB3B17E4D4E332955.0862028596DF4668AB1D736D2B40424F"
                     "UsePlugInResources" = "11:FALSE"
                     }
@@ -1349,20 +1321,6 @@
                     "ParentName" = "8:_BE7C8A748AB042DFB3B17E4D4E332955.0862028596DF4668AB1D736D2B40424F"
                     "UsePlugInResources" = "11:FALSE"
                     }
-                    "_22CCBAFDC2FF678459081E4884E22F82.0862028596DF4668AB1D736D2B40424F"
-                    {
-                    "Name" = "8:_22CCBAFDC2FF678459081E4884E22F82.0862028596DF4668AB1D736D2B40424F"
-                    "DisplayName" = "8:"
-                    "Description" = "8:"
-                    "Type" = "3:2"
-                    "ContextData" = "8:InstallToGAC=;IsolateToManifest=_1B862C84828D4704B974EF54CDC6F2F0.0862028596DF4668AB1D736D2B40424F"
-                    "Attributes" = "3:0"
-                    "Setting" = "3:2"
-                    "Value" = "8:_1B862C84828D4704B974EF54CDC6F2F0.0862028596DF4668AB1D736D2B40424F"
-                    "DefaultValue" = "8:_1B862C84828D4704B974EF54CDC6F2F0.0862028596DF4668AB1D736D2B40424F"
-                    "ParentName" = "8:_BE7C8A748AB042DFB3B17E4D4E332955.0862028596DF4668AB1D736D2B40424F"
-                    "UsePlugInResources" = "11:FALSE"
-                    }
                     "_235984E98BA1A932DF9396C8ACE21739.0862028596DF4668AB1D736D2B40424F"
                     {
                     "Name" = "8:_235984E98BA1A932DF9396C8ACE21739.0862028596DF4668AB1D736D2B40424F"
@@ -1374,34 +1332,6 @@
                     "Setting" = "3:2"
                     "Value" = "8:_EA6E8D5AA87340F9846E25811D3BF5FF.0862028596DF4668AB1D736D2B40424F"
                     "DefaultValue" = "8:_EA6E8D5AA87340F9846E25811D3BF5FF.0862028596DF4668AB1D736D2B40424F"
-                    "ParentName" = "8:_BE7C8A748AB042DFB3B17E4D4E332955.0862028596DF4668AB1D736D2B40424F"
-                    "UsePlugInResources" = "11:FALSE"
-                    }
-                    "_24C98D69C15669B68903DCE075E4492B.0862028596DF4668AB1D736D2B40424F"
-                    {
-                    "Name" = "8:_24C98D69C15669B68903DCE075E4492B.0862028596DF4668AB1D736D2B40424F"
-                    "DisplayName" = "8:"
-                    "Description" = "8:"
-                    "Type" = "3:2"
-                    "ContextData" = "8:InstallToGAC=;IsolateToManifest=_13D448C2139643F5A6918B01FA8CB5DF.0862028596DF4668AB1D736D2B40424F"
-                    "Attributes" = "3:0"
-                    "Setting" = "3:2"
-                    "Value" = "8:_13D448C2139643F5A6918B01FA8CB5DF.0862028596DF4668AB1D736D2B40424F"
-                    "DefaultValue" = "8:_13D448C2139643F5A6918B01FA8CB5DF.0862028596DF4668AB1D736D2B40424F"
-                    "ParentName" = "8:_BE7C8A748AB042DFB3B17E4D4E332955.0862028596DF4668AB1D736D2B40424F"
-                    "UsePlugInResources" = "11:FALSE"
-                    }
-                    "_2502F49D57A193C2DF9D001E422E585F.0862028596DF4668AB1D736D2B40424F"
-                    {
-                    "Name" = "8:_2502F49D57A193C2DF9D001E422E585F.0862028596DF4668AB1D736D2B40424F"
-                    "DisplayName" = "8:"
-                    "Description" = "8:"
-                    "Type" = "3:2"
-                    "ContextData" = "8:InstallToGAC=;IsolateToManifest=_43E459888A275480E1BD456D4516A640.0862028596DF4668AB1D736D2B40424F"
-                    "Attributes" = "3:0"
-                    "Setting" = "3:2"
-                    "Value" = "8:_43E459888A275480E1BD456D4516A640.0862028596DF4668AB1D736D2B40424F"
-                    "DefaultValue" = "8:_43E459888A275480E1BD456D4516A640.0862028596DF4668AB1D736D2B40424F"
                     "ParentName" = "8:_BE7C8A748AB042DFB3B17E4D4E332955.0862028596DF4668AB1D736D2B40424F"
                     "UsePlugInResources" = "11:FALSE"
                     }
@@ -1517,34 +1447,6 @@
                     "ParentName" = "8:_BE7C8A748AB042DFB3B17E4D4E332955.0862028596DF4668AB1D736D2B40424F"
                     "UsePlugInResources" = "11:FALSE"
                     }
-                    "_3439440481858BF9741B747CCF05904C.0862028596DF4668AB1D736D2B40424F"
-                    {
-                    "Name" = "8:_3439440481858BF9741B747CCF05904C.0862028596DF4668AB1D736D2B40424F"
-                    "DisplayName" = "8:"
-                    "Description" = "8:"
-                    "Type" = "3:2"
-                    "ContextData" = "8:InstallToGAC=;IsolateToManifest=_FAEC8D5E7D7946D6B028D47DDEDA4E96.0862028596DF4668AB1D736D2B40424F"
-                    "Attributes" = "3:0"
-                    "Setting" = "3:2"
-                    "Value" = "8:_FAEC8D5E7D7946D6B028D47DDEDA4E96.0862028596DF4668AB1D736D2B40424F"
-                    "DefaultValue" = "8:_FAEC8D5E7D7946D6B028D47DDEDA4E96.0862028596DF4668AB1D736D2B40424F"
-                    "ParentName" = "8:_BE7C8A748AB042DFB3B17E4D4E332955.0862028596DF4668AB1D736D2B40424F"
-                    "UsePlugInResources" = "11:FALSE"
-                    }
-                    "_3488C5AD58B62A1040D7C68AE87C2408.0862028596DF4668AB1D736D2B40424F"
-                    {
-                    "Name" = "8:_3488C5AD58B62A1040D7C68AE87C2408.0862028596DF4668AB1D736D2B40424F"
-                    "DisplayName" = "8:"
-                    "Description" = "8:"
-                    "Type" = "3:2"
-                    "ContextData" = "8:InstallToGAC=;IsolateToManifest=_67E8E0F1B4194C90B8512C7015C7F02E.0862028596DF4668AB1D736D2B40424F"
-                    "Attributes" = "3:0"
-                    "Setting" = "3:2"
-                    "Value" = "8:_67E8E0F1B4194C90B8512C7015C7F02E.0862028596DF4668AB1D736D2B40424F"
-                    "DefaultValue" = "8:_67E8E0F1B4194C90B8512C7015C7F02E.0862028596DF4668AB1D736D2B40424F"
-                    "ParentName" = "8:_BE7C8A748AB042DFB3B17E4D4E332955.0862028596DF4668AB1D736D2B40424F"
-                    "UsePlugInResources" = "11:FALSE"
-                    }
                     "_3547DA915F63C242B8BE1EFA90CAE44D.0862028596DF4668AB1D736D2B40424F"
                     {
                     "Name" = "8:_3547DA915F63C242B8BE1EFA90CAE44D.0862028596DF4668AB1D736D2B40424F"
@@ -1629,20 +1531,6 @@
                     "ParentName" = "8:_BE7C8A748AB042DFB3B17E4D4E332955.0862028596DF4668AB1D736D2B40424F"
                     "UsePlugInResources" = "11:FALSE"
                     }
-                    "_3CE0DF17B9B857BC74D318700A1789FC.0862028596DF4668AB1D736D2B40424F"
-                    {
-                    "Name" = "8:_3CE0DF17B9B857BC74D318700A1789FC.0862028596DF4668AB1D736D2B40424F"
-                    "DisplayName" = "8:"
-                    "Description" = "8:"
-                    "Type" = "3:2"
-                    "ContextData" = "8:InstallToGAC=;IsolateToManifest=_E71C20ACF4664261A7ECB8759C724614.0862028596DF4668AB1D736D2B40424F"
-                    "Attributes" = "3:0"
-                    "Setting" = "3:2"
-                    "Value" = "8:_E71C20ACF4664261A7ECB8759C724614.0862028596DF4668AB1D736D2B40424F"
-                    "DefaultValue" = "8:_E71C20ACF4664261A7ECB8759C724614.0862028596DF4668AB1D736D2B40424F"
-                    "ParentName" = "8:_BE7C8A748AB042DFB3B17E4D4E332955.0862028596DF4668AB1D736D2B40424F"
-                    "UsePlugInResources" = "11:FALSE"
-                    }
                     "_3DEDEBA34B47E5D5223689699C1B58F1.0862028596DF4668AB1D736D2B40424F"
                     {
                     "Name" = "8:_3DEDEBA34B47E5D5223689699C1B58F1.0862028596DF4668AB1D736D2B40424F"
@@ -1710,20 +1598,6 @@
                     "Setting" = "3:2"
                     "Value" = "8:_ACBB7A53E4154411A8736DB66962315C.0862028596DF4668AB1D736D2B40424F"
                     "DefaultValue" = "8:_ACBB7A53E4154411A8736DB66962315C.0862028596DF4668AB1D736D2B40424F"
-                    "ParentName" = "8:_BE7C8A748AB042DFB3B17E4D4E332955.0862028596DF4668AB1D736D2B40424F"
-                    "UsePlugInResources" = "11:FALSE"
-                    }
-                    "_45EF7B8B107C91809DD68DCEF7F103BA.0862028596DF4668AB1D736D2B40424F"
-                    {
-                    "Name" = "8:_45EF7B8B107C91809DD68DCEF7F103BA.0862028596DF4668AB1D736D2B40424F"
-                    "DisplayName" = "8:"
-                    "Description" = "8:"
-                    "Type" = "3:2"
-                    "ContextData" = "8:InstallToGAC=;IsolateToManifest=_4C1DEC9B3B0A45599A31D801EB69E151.0862028596DF4668AB1D736D2B40424F"
-                    "Attributes" = "3:0"
-                    "Setting" = "3:2"
-                    "Value" = "8:_4C1DEC9B3B0A45599A31D801EB69E151.0862028596DF4668AB1D736D2B40424F"
-                    "DefaultValue" = "8:_4C1DEC9B3B0A45599A31D801EB69E151.0862028596DF4668AB1D736D2B40424F"
                     "ParentName" = "8:_BE7C8A748AB042DFB3B17E4D4E332955.0862028596DF4668AB1D736D2B40424F"
                     "UsePlugInResources" = "11:FALSE"
                     }
@@ -1923,20 +1797,6 @@
                     "ParentName" = "8:_BE7C8A748AB042DFB3B17E4D4E332955.0862028596DF4668AB1D736D2B40424F"
                     "UsePlugInResources" = "11:FALSE"
                     }
-                    "_578A42D00C60D21725ECE3E4F8452306.0862028596DF4668AB1D736D2B40424F"
-                    {
-                    "Name" = "8:_578A42D00C60D21725ECE3E4F8452306.0862028596DF4668AB1D736D2B40424F"
-                    "DisplayName" = "8:"
-                    "Description" = "8:"
-                    "Type" = "3:2"
-                    "ContextData" = "8:InstallToGAC=;IsolateToManifest=_57636C844DC7404787926E8B88D6C05A.0862028596DF4668AB1D736D2B40424F"
-                    "Attributes" = "3:0"
-                    "Setting" = "3:2"
-                    "Value" = "8:_57636C844DC7404787926E8B88D6C05A.0862028596DF4668AB1D736D2B40424F"
-                    "DefaultValue" = "8:_57636C844DC7404787926E8B88D6C05A.0862028596DF4668AB1D736D2B40424F"
-                    "ParentName" = "8:_BE7C8A748AB042DFB3B17E4D4E332955.0862028596DF4668AB1D736D2B40424F"
-                    "UsePlugInResources" = "11:FALSE"
-                    }
                     "_5D3E9BF5A78640438097CF36879EB2EF.0862028596DF4668AB1D736D2B40424F"
                     {
                     "Name" = "8:_5D3E9BF5A78640438097CF36879EB2EF.0862028596DF4668AB1D736D2B40424F"
@@ -1976,20 +1836,6 @@
                     "Setting" = "3:2"
                     "Value" = "8:_BE201112BEA142F6AEC9074CDB62C3C1.0862028596DF4668AB1D736D2B40424F"
                     "DefaultValue" = "8:_BE201112BEA142F6AEC9074CDB62C3C1.0862028596DF4668AB1D736D2B40424F"
-                    "ParentName" = "8:_BE7C8A748AB042DFB3B17E4D4E332955.0862028596DF4668AB1D736D2B40424F"
-                    "UsePlugInResources" = "11:FALSE"
-                    }
-                    "_612FF45792AE972323946FA0C6820D34.0862028596DF4668AB1D736D2B40424F"
-                    {
-                    "Name" = "8:_612FF45792AE972323946FA0C6820D34.0862028596DF4668AB1D736D2B40424F"
-                    "DisplayName" = "8:"
-                    "Description" = "8:"
-                    "Type" = "3:2"
-                    "ContextData" = "8:InstallToGAC=;IsolateToManifest=_F4B1CF931C44450FB1E4876D3041921F.0862028596DF4668AB1D736D2B40424F"
-                    "Attributes" = "3:0"
-                    "Setting" = "3:2"
-                    "Value" = "8:_F4B1CF931C44450FB1E4876D3041921F.0862028596DF4668AB1D736D2B40424F"
-                    "DefaultValue" = "8:_F4B1CF931C44450FB1E4876D3041921F.0862028596DF4668AB1D736D2B40424F"
                     "ParentName" = "8:_BE7C8A748AB042DFB3B17E4D4E332955.0862028596DF4668AB1D736D2B40424F"
                     "UsePlugInResources" = "11:FALSE"
                     }
@@ -2315,20 +2161,6 @@
                     "ParentName" = "8:_BE7C8A748AB042DFB3B17E4D4E332955.0862028596DF4668AB1D736D2B40424F"
                     "UsePlugInResources" = "11:FALSE"
                     }
-                    "_7DFB0E20668011BE0A613646BA8406C3.0862028596DF4668AB1D736D2B40424F"
-                    {
-                    "Name" = "8:_7DFB0E20668011BE0A613646BA8406C3.0862028596DF4668AB1D736D2B40424F"
-                    "DisplayName" = "8:"
-                    "Description" = "8:"
-                    "Type" = "3:2"
-                    "ContextData" = "8:InstallToGAC=;IsolateToManifest=_AADD36F6B97F403495AEC87429288C87.0862028596DF4668AB1D736D2B40424F"
-                    "Attributes" = "3:0"
-                    "Setting" = "3:2"
-                    "Value" = "8:_AADD36F6B97F403495AEC87429288C87.0862028596DF4668AB1D736D2B40424F"
-                    "DefaultValue" = "8:_AADD36F6B97F403495AEC87429288C87.0862028596DF4668AB1D736D2B40424F"
-                    "ParentName" = "8:_BE7C8A748AB042DFB3B17E4D4E332955.0862028596DF4668AB1D736D2B40424F"
-                    "UsePlugInResources" = "11:FALSE"
-                    }
                     "_7EFE6E7447933C4325BBCFAF440C98E9.0862028596DF4668AB1D736D2B40424F"
                     {
                     "Name" = "8:_7EFE6E7447933C4325BBCFAF440C98E9.0862028596DF4668AB1D736D2B40424F"
@@ -2382,20 +2214,6 @@
                     "Setting" = "3:2"
                     "Value" = "8:_8B5D3525B7D040A99A5644A3FF3BEA68.0862028596DF4668AB1D736D2B40424F"
                     "DefaultValue" = "8:_8B5D3525B7D040A99A5644A3FF3BEA68.0862028596DF4668AB1D736D2B40424F"
-                    "ParentName" = "8:_BE7C8A748AB042DFB3B17E4D4E332955.0862028596DF4668AB1D736D2B40424F"
-                    "UsePlugInResources" = "11:FALSE"
-                    }
-                    "_862903D9BA94E6A290AFAB479D88104A.0862028596DF4668AB1D736D2B40424F"
-                    {
-                    "Name" = "8:_862903D9BA94E6A290AFAB479D88104A.0862028596DF4668AB1D736D2B40424F"
-                    "DisplayName" = "8:"
-                    "Description" = "8:"
-                    "Type" = "3:2"
-                    "ContextData" = "8:InstallToGAC=;IsolateToManifest=_642141C11D594B71BEF485398FF1066A.0862028596DF4668AB1D736D2B40424F"
-                    "Attributes" = "3:0"
-                    "Setting" = "3:2"
-                    "Value" = "8:_642141C11D594B71BEF485398FF1066A.0862028596DF4668AB1D736D2B40424F"
-                    "DefaultValue" = "8:_642141C11D594B71BEF485398FF1066A.0862028596DF4668AB1D736D2B40424F"
                     "ParentName" = "8:_BE7C8A748AB042DFB3B17E4D4E332955.0862028596DF4668AB1D736D2B40424F"
                     "UsePlugInResources" = "11:FALSE"
                     }
@@ -2455,20 +2273,6 @@
                     "ParentName" = "8:_BE7C8A748AB042DFB3B17E4D4E332955.0862028596DF4668AB1D736D2B40424F"
                     "UsePlugInResources" = "11:FALSE"
                     }
-                    "_8C400F6D2826930D444ED5C0B72EA250.0862028596DF4668AB1D736D2B40424F"
-                    {
-                    "Name" = "8:_8C400F6D2826930D444ED5C0B72EA250.0862028596DF4668AB1D736D2B40424F"
-                    "DisplayName" = "8:"
-                    "Description" = "8:"
-                    "Type" = "3:2"
-                    "ContextData" = "8:InstallToGAC=;IsolateToManifest=_C258DCC2A97441CC8D4CE99B30CCFE30.0862028596DF4668AB1D736D2B40424F"
-                    "Attributes" = "3:0"
-                    "Setting" = "3:2"
-                    "Value" = "8:_C258DCC2A97441CC8D4CE99B30CCFE30.0862028596DF4668AB1D736D2B40424F"
-                    "DefaultValue" = "8:_C258DCC2A97441CC8D4CE99B30CCFE30.0862028596DF4668AB1D736D2B40424F"
-                    "ParentName" = "8:_BE7C8A748AB042DFB3B17E4D4E332955.0862028596DF4668AB1D736D2B40424F"
-                    "UsePlugInResources" = "11:FALSE"
-                    }
                     "_8C6F4F8A059630F79CC669648B174074.0862028596DF4668AB1D736D2B40424F"
                     {
                     "Name" = "8:_8C6F4F8A059630F79CC669648B174074.0862028596DF4668AB1D736D2B40424F"
@@ -2480,20 +2284,6 @@
                     "Setting" = "3:2"
                     "Value" = "8:_D6635C186E7340FFB7ED7C89CF131887.0862028596DF4668AB1D736D2B40424F"
                     "DefaultValue" = "8:_D6635C186E7340FFB7ED7C89CF131887.0862028596DF4668AB1D736D2B40424F"
-                    "ParentName" = "8:_BE7C8A748AB042DFB3B17E4D4E332955.0862028596DF4668AB1D736D2B40424F"
-                    "UsePlugInResources" = "11:FALSE"
-                    }
-                    "_8D35E410C1713AD8ED0FA6BB2453F248.0862028596DF4668AB1D736D2B40424F"
-                    {
-                    "Name" = "8:_8D35E410C1713AD8ED0FA6BB2453F248.0862028596DF4668AB1D736D2B40424F"
-                    "DisplayName" = "8:"
-                    "Description" = "8:"
-                    "Type" = "3:2"
-                    "ContextData" = "8:InstallToGAC=;IsolateToManifest=_FC8986371CB34FDE85D9F41E61CF301E.0862028596DF4668AB1D736D2B40424F"
-                    "Attributes" = "3:0"
-                    "Setting" = "3:2"
-                    "Value" = "8:_FC8986371CB34FDE85D9F41E61CF301E.0862028596DF4668AB1D736D2B40424F"
-                    "DefaultValue" = "8:_FC8986371CB34FDE85D9F41E61CF301E.0862028596DF4668AB1D736D2B40424F"
                     "ParentName" = "8:_BE7C8A748AB042DFB3B17E4D4E332955.0862028596DF4668AB1D736D2B40424F"
                     "UsePlugInResources" = "11:FALSE"
                     }
@@ -2567,20 +2357,6 @@
                     "ParentName" = "8:_BE7C8A748AB042DFB3B17E4D4E332955.0862028596DF4668AB1D736D2B40424F"
                     "UsePlugInResources" = "11:FALSE"
                     }
-                    "_924E8247C23410F73FC46CCB9C33880B.0862028596DF4668AB1D736D2B40424F"
-                    {
-                    "Name" = "8:_924E8247C23410F73FC46CCB9C33880B.0862028596DF4668AB1D736D2B40424F"
-                    "DisplayName" = "8:"
-                    "Description" = "8:"
-                    "Type" = "3:2"
-                    "ContextData" = "8:InstallToGAC=;IsolateToManifest=_FDA28938341845008A82CE6C5CC78608.0862028596DF4668AB1D736D2B40424F"
-                    "Attributes" = "3:0"
-                    "Setting" = "3:2"
-                    "Value" = "8:_FDA28938341845008A82CE6C5CC78608.0862028596DF4668AB1D736D2B40424F"
-                    "DefaultValue" = "8:_FDA28938341845008A82CE6C5CC78608.0862028596DF4668AB1D736D2B40424F"
-                    "ParentName" = "8:_BE7C8A748AB042DFB3B17E4D4E332955.0862028596DF4668AB1D736D2B40424F"
-                    "UsePlugInResources" = "11:FALSE"
-                    }
                     "_935A7198E41397A2EBD2D9B61E60B366.0862028596DF4668AB1D736D2B40424F"
                     {
                     "Name" = "8:_935A7198E41397A2EBD2D9B61E60B366.0862028596DF4668AB1D736D2B40424F"
@@ -2634,20 +2410,6 @@
                     "Setting" = "3:2"
                     "Value" = "8:_BBC7B27A5D404945B6742EE0582F6138.0862028596DF4668AB1D736D2B40424F"
                     "DefaultValue" = "8:_BBC7B27A5D404945B6742EE0582F6138.0862028596DF4668AB1D736D2B40424F"
-                    "ParentName" = "8:_BE7C8A748AB042DFB3B17E4D4E332955.0862028596DF4668AB1D736D2B40424F"
-                    "UsePlugInResources" = "11:FALSE"
-                    }
-                    "_97520F3B87ACD32381B5E453C0C7AB0E.0862028596DF4668AB1D736D2B40424F"
-                    {
-                    "Name" = "8:_97520F3B87ACD32381B5E453C0C7AB0E.0862028596DF4668AB1D736D2B40424F"
-                    "DisplayName" = "8:"
-                    "Description" = "8:"
-                    "Type" = "3:2"
-                    "ContextData" = "8:InstallToGAC=;IsolateToManifest=_F319F875992947DB96A70712D6CF39D4.0862028596DF4668AB1D736D2B40424F"
-                    "Attributes" = "3:0"
-                    "Setting" = "3:2"
-                    "Value" = "8:_F319F875992947DB96A70712D6CF39D4.0862028596DF4668AB1D736D2B40424F"
-                    "DefaultValue" = "8:_F319F875992947DB96A70712D6CF39D4.0862028596DF4668AB1D736D2B40424F"
                     "ParentName" = "8:_BE7C8A748AB042DFB3B17E4D4E332955.0862028596DF4668AB1D736D2B40424F"
                     "UsePlugInResources" = "11:FALSE"
                     }
@@ -2763,20 +2525,6 @@
                     "ParentName" = "8:_BE7C8A748AB042DFB3B17E4D4E332955.0862028596DF4668AB1D736D2B40424F"
                     "UsePlugInResources" = "11:FALSE"
                     }
-                    "_9DE306A3600C3E1F575353FB0FA7865D.0862028596DF4668AB1D736D2B40424F"
-                    {
-                    "Name" = "8:_9DE306A3600C3E1F575353FB0FA7865D.0862028596DF4668AB1D736D2B40424F"
-                    "DisplayName" = "8:"
-                    "Description" = "8:"
-                    "Type" = "3:2"
-                    "ContextData" = "8:InstallToGAC=;IsolateToManifest=_210F8294099844DCBA0719148283D6E8.0862028596DF4668AB1D736D2B40424F"
-                    "Attributes" = "3:0"
-                    "Setting" = "3:2"
-                    "Value" = "8:_210F8294099844DCBA0719148283D6E8.0862028596DF4668AB1D736D2B40424F"
-                    "DefaultValue" = "8:_210F8294099844DCBA0719148283D6E8.0862028596DF4668AB1D736D2B40424F"
-                    "ParentName" = "8:_BE7C8A748AB042DFB3B17E4D4E332955.0862028596DF4668AB1D736D2B40424F"
-                    "UsePlugInResources" = "11:FALSE"
-                    }
                     "_9E8606A63CC7D1DBDA989B3F12810D7D.0862028596DF4668AB1D736D2B40424F"
                     {
                     "Name" = "8:_9E8606A63CC7D1DBDA989B3F12810D7D.0862028596DF4668AB1D736D2B40424F"
@@ -2788,20 +2536,6 @@
                     "Setting" = "3:2"
                     "Value" = "8:_D92BDDE4F7B448C1A5754A94F1EF5B29.0862028596DF4668AB1D736D2B40424F"
                     "DefaultValue" = "8:_D92BDDE4F7B448C1A5754A94F1EF5B29.0862028596DF4668AB1D736D2B40424F"
-                    "ParentName" = "8:_BE7C8A748AB042DFB3B17E4D4E332955.0862028596DF4668AB1D736D2B40424F"
-                    "UsePlugInResources" = "11:FALSE"
-                    }
-                    "_A104CC7E802481BA372FC2163EE8A941.0862028596DF4668AB1D736D2B40424F"
-                    {
-                    "Name" = "8:_A104CC7E802481BA372FC2163EE8A941.0862028596DF4668AB1D736D2B40424F"
-                    "DisplayName" = "8:"
-                    "Description" = "8:"
-                    "Type" = "3:2"
-                    "ContextData" = "8:InstallToGAC=;IsolateToManifest=_40384720FEE043ECA975BD43593A3F50.0862028596DF4668AB1D736D2B40424F"
-                    "Attributes" = "3:0"
-                    "Setting" = "3:2"
-                    "Value" = "8:_40384720FEE043ECA975BD43593A3F50.0862028596DF4668AB1D736D2B40424F"
-                    "DefaultValue" = "8:_40384720FEE043ECA975BD43593A3F50.0862028596DF4668AB1D736D2B40424F"
                     "ParentName" = "8:_BE7C8A748AB042DFB3B17E4D4E332955.0862028596DF4668AB1D736D2B40424F"
                     "UsePlugInResources" = "11:FALSE"
                     }
@@ -2875,20 +2609,6 @@
                     "ParentName" = "8:_BE7C8A748AB042DFB3B17E4D4E332955.0862028596DF4668AB1D736D2B40424F"
                     "UsePlugInResources" = "11:FALSE"
                     }
-                    "_AB58C1222C2D1B15502A6F4F6C3C841C.0862028596DF4668AB1D736D2B40424F"
-                    {
-                    "Name" = "8:_AB58C1222C2D1B15502A6F4F6C3C841C.0862028596DF4668AB1D736D2B40424F"
-                    "DisplayName" = "8:"
-                    "Description" = "8:"
-                    "Type" = "3:2"
-                    "ContextData" = "8:InstallToGAC=;IsolateToManifest=_67DF35398F074D428CB47E5DAD55D329.0862028596DF4668AB1D736D2B40424F"
-                    "Attributes" = "3:0"
-                    "Setting" = "3:2"
-                    "Value" = "8:_67DF35398F074D428CB47E5DAD55D329.0862028596DF4668AB1D736D2B40424F"
-                    "DefaultValue" = "8:_67DF35398F074D428CB47E5DAD55D329.0862028596DF4668AB1D736D2B40424F"
-                    "ParentName" = "8:_BE7C8A748AB042DFB3B17E4D4E332955.0862028596DF4668AB1D736D2B40424F"
-                    "UsePlugInResources" = "11:FALSE"
-                    }
                     "_ADFF1B1A2B1B4A98306EAAD3B1C8C0BD.0862028596DF4668AB1D736D2B40424F"
                     {
                     "Name" = "8:_ADFF1B1A2B1B4A98306EAAD3B1C8C0BD.0862028596DF4668AB1D736D2B40424F"
@@ -2917,20 +2637,6 @@
                     "ParentName" = "8:_BE7C8A748AB042DFB3B17E4D4E332955.0862028596DF4668AB1D736D2B40424F"
                     "UsePlugInResources" = "11:FALSE"
                     }
-                    "_B15F93B99288B9CE353631DC47103F76.0862028596DF4668AB1D736D2B40424F"
-                    {
-                    "Name" = "8:_B15F93B99288B9CE353631DC47103F76.0862028596DF4668AB1D736D2B40424F"
-                    "DisplayName" = "8:"
-                    "Description" = "8:"
-                    "Type" = "3:2"
-                    "ContextData" = "8:InstallToGAC=;IsolateToManifest=_E2C042031A57431A9205FC9FCB561C49.0862028596DF4668AB1D736D2B40424F"
-                    "Attributes" = "3:0"
-                    "Setting" = "3:2"
-                    "Value" = "8:_E2C042031A57431A9205FC9FCB561C49.0862028596DF4668AB1D736D2B40424F"
-                    "DefaultValue" = "8:_E2C042031A57431A9205FC9FCB561C49.0862028596DF4668AB1D736D2B40424F"
-                    "ParentName" = "8:_BE7C8A748AB042DFB3B17E4D4E332955.0862028596DF4668AB1D736D2B40424F"
-                    "UsePlugInResources" = "11:FALSE"
-                    }
                     "_B199D65363042F7B6D42E9BF16A9EEF4.0862028596DF4668AB1D736D2B40424F"
                     {
                     "Name" = "8:_B199D65363042F7B6D42E9BF16A9EEF4.0862028596DF4668AB1D736D2B40424F"
@@ -2945,20 +2651,6 @@
                     "ParentName" = "8:_BE7C8A748AB042DFB3B17E4D4E332955.0862028596DF4668AB1D736D2B40424F"
                     "UsePlugInResources" = "11:FALSE"
                     }
-                    "_B232179ED584D4CB7621C5A1F7AF92EE.0862028596DF4668AB1D736D2B40424F"
-                    {
-                    "Name" = "8:_B232179ED584D4CB7621C5A1F7AF92EE.0862028596DF4668AB1D736D2B40424F"
-                    "DisplayName" = "8:"
-                    "Description" = "8:"
-                    "Type" = "3:2"
-                    "ContextData" = "8:InstallToGAC=;IsolateToManifest=_D31E1D294B5D4340BD3E59D1E766383D.0862028596DF4668AB1D736D2B40424F"
-                    "Attributes" = "3:0"
-                    "Setting" = "3:2"
-                    "Value" = "8:_D31E1D294B5D4340BD3E59D1E766383D.0862028596DF4668AB1D736D2B40424F"
-                    "DefaultValue" = "8:_D31E1D294B5D4340BD3E59D1E766383D.0862028596DF4668AB1D736D2B40424F"
-                    "ParentName" = "8:_BE7C8A748AB042DFB3B17E4D4E332955.0862028596DF4668AB1D736D2B40424F"
-                    "UsePlugInResources" = "11:FALSE"
-                    }
                     "_B617D783D38324A3595D1FD04B1B9E35.0862028596DF4668AB1D736D2B40424F"
                     {
                     "Name" = "8:_B617D783D38324A3595D1FD04B1B9E35.0862028596DF4668AB1D736D2B40424F"
@@ -2970,20 +2662,6 @@
                     "Setting" = "3:2"
                     "Value" = "8:_603ACD53734241D5ACC02B6048B91CE2.0862028596DF4668AB1D736D2B40424F"
                     "DefaultValue" = "8:_603ACD53734241D5ACC02B6048B91CE2.0862028596DF4668AB1D736D2B40424F"
-                    "ParentName" = "8:_BE7C8A748AB042DFB3B17E4D4E332955.0862028596DF4668AB1D736D2B40424F"
-                    "UsePlugInResources" = "11:FALSE"
-                    }
-                    "_B6C9860C7B3AD206676F54E378D48B68.0862028596DF4668AB1D736D2B40424F"
-                    {
-                    "Name" = "8:_B6C9860C7B3AD206676F54E378D48B68.0862028596DF4668AB1D736D2B40424F"
-                    "DisplayName" = "8:"
-                    "Description" = "8:"
-                    "Type" = "3:2"
-                    "ContextData" = "8:InstallToGAC=;IsolateToManifest=_190CF557D39E4FD5A741CA40C94A7DC5.0862028596DF4668AB1D736D2B40424F"
-                    "Attributes" = "3:0"
-                    "Setting" = "3:2"
-                    "Value" = "8:_190CF557D39E4FD5A741CA40C94A7DC5.0862028596DF4668AB1D736D2B40424F"
-                    "DefaultValue" = "8:_190CF557D39E4FD5A741CA40C94A7DC5.0862028596DF4668AB1D736D2B40424F"
                     "ParentName" = "8:_BE7C8A748AB042DFB3B17E4D4E332955.0862028596DF4668AB1D736D2B40424F"
                     "UsePlugInResources" = "11:FALSE"
                     }
@@ -3153,20 +2831,6 @@
                     "ParentName" = "8:_BE7C8A748AB042DFB3B17E4D4E332955.0862028596DF4668AB1D736D2B40424F"
                     "UsePlugInResources" = "11:FALSE"
                     }
-                    "_C1646F1C991A9E282A9B496C611BFEB3.0862028596DF4668AB1D736D2B40424F"
-                    {
-                    "Name" = "8:_C1646F1C991A9E282A9B496C611BFEB3.0862028596DF4668AB1D736D2B40424F"
-                    "DisplayName" = "8:"
-                    "Description" = "8:"
-                    "Type" = "3:2"
-                    "ContextData" = "8:InstallToGAC=;IsolateToManifest=_CFA5745E6EEB4CD7A5170E2B8AA28D94.0862028596DF4668AB1D736D2B40424F"
-                    "Attributes" = "3:0"
-                    "Setting" = "3:2"
-                    "Value" = "8:_CFA5745E6EEB4CD7A5170E2B8AA28D94.0862028596DF4668AB1D736D2B40424F"
-                    "DefaultValue" = "8:_CFA5745E6EEB4CD7A5170E2B8AA28D94.0862028596DF4668AB1D736D2B40424F"
-                    "ParentName" = "8:_BE7C8A748AB042DFB3B17E4D4E332955.0862028596DF4668AB1D736D2B40424F"
-                    "UsePlugInResources" = "11:FALSE"
-                    }
                     "_C23ACACBE00AA87894E16B173773AF1C.0862028596DF4668AB1D736D2B40424F"
                     {
                     "Name" = "8:_C23ACACBE00AA87894E16B173773AF1C.0862028596DF4668AB1D736D2B40424F"
@@ -3178,20 +2842,6 @@
                     "Setting" = "3:2"
                     "Value" = "8:_2D5946782776470DAE7A7B8F611D2C46.0862028596DF4668AB1D736D2B40424F"
                     "DefaultValue" = "8:_2D5946782776470DAE7A7B8F611D2C46.0862028596DF4668AB1D736D2B40424F"
-                    "ParentName" = "8:_BE7C8A748AB042DFB3B17E4D4E332955.0862028596DF4668AB1D736D2B40424F"
-                    "UsePlugInResources" = "11:FALSE"
-                    }
-                    "_C263879B3DE3171B9B5C2EA5465C3E77.0862028596DF4668AB1D736D2B40424F"
-                    {
-                    "Name" = "8:_C263879B3DE3171B9B5C2EA5465C3E77.0862028596DF4668AB1D736D2B40424F"
-                    "DisplayName" = "8:"
-                    "Description" = "8:"
-                    "Type" = "3:2"
-                    "ContextData" = "8:InstallToGAC=;IsolateToManifest=_36716D06930941819F6E1EF2088B7861.0862028596DF4668AB1D736D2B40424F"
-                    "Attributes" = "3:0"
-                    "Setting" = "3:2"
-                    "Value" = "8:_36716D06930941819F6E1EF2088B7861.0862028596DF4668AB1D736D2B40424F"
-                    "DefaultValue" = "8:_36716D06930941819F6E1EF2088B7861.0862028596DF4668AB1D736D2B40424F"
                     "ParentName" = "8:_BE7C8A748AB042DFB3B17E4D4E332955.0862028596DF4668AB1D736D2B40424F"
                     "UsePlugInResources" = "11:FALSE"
                     }
@@ -3335,20 +2985,6 @@
                     "ParentName" = "8:_BE7C8A748AB042DFB3B17E4D4E332955.0862028596DF4668AB1D736D2B40424F"
                     "UsePlugInResources" = "11:FALSE"
                     }
-                    "_D0BACDC33326F091ADF63CE059BFE1F8.0862028596DF4668AB1D736D2B40424F"
-                    {
-                    "Name" = "8:_D0BACDC33326F091ADF63CE059BFE1F8.0862028596DF4668AB1D736D2B40424F"
-                    "DisplayName" = "8:"
-                    "Description" = "8:"
-                    "Type" = "3:2"
-                    "ContextData" = "8:InstallToGAC=;IsolateToManifest=_C74366375A7448EABFE460BBBC5E142A.0862028596DF4668AB1D736D2B40424F"
-                    "Attributes" = "3:0"
-                    "Setting" = "3:2"
-                    "Value" = "8:_C74366375A7448EABFE460BBBC5E142A.0862028596DF4668AB1D736D2B40424F"
-                    "DefaultValue" = "8:_C74366375A7448EABFE460BBBC5E142A.0862028596DF4668AB1D736D2B40424F"
-                    "ParentName" = "8:_BE7C8A748AB042DFB3B17E4D4E332955.0862028596DF4668AB1D736D2B40424F"
-                    "UsePlugInResources" = "11:FALSE"
-                    }
                     "_D0F6277F4B7B32C3CCC015E892EFA1AB.0862028596DF4668AB1D736D2B40424F"
                     {
                     "Name" = "8:_D0F6277F4B7B32C3CCC015E892EFA1AB.0862028596DF4668AB1D736D2B40424F"
@@ -3363,17 +2999,17 @@
                     "ParentName" = "8:_BE7C8A748AB042DFB3B17E4D4E332955.0862028596DF4668AB1D736D2B40424F"
                     "UsePlugInResources" = "11:FALSE"
                     }
-                    "_D2AEA33D6E1996234B0C70E398638BFC.0862028596DF4668AB1D736D2B40424F"
+                    "_D22875FCA16167683D85F0A1835D49E5.0862028596DF4668AB1D736D2B40424F"
                     {
-                    "Name" = "8:_D2AEA33D6E1996234B0C70E398638BFC.0862028596DF4668AB1D736D2B40424F"
+                    "Name" = "8:_D22875FCA16167683D85F0A1835D49E5.0862028596DF4668AB1D736D2B40424F"
                     "DisplayName" = "8:"
                     "Description" = "8:"
                     "Type" = "3:2"
-                    "ContextData" = "8:InstallToGAC=;IsolateToManifest=_B145E5EB173145D699545451BD2BAD93.0862028596DF4668AB1D736D2B40424F"
+                    "ContextData" = "8:InstallToGAC=;IsolateToManifest=_2E378C60DB144793BE361E98417441BE.0862028596DF4668AB1D736D2B40424F"
                     "Attributes" = "3:0"
                     "Setting" = "3:2"
-                    "Value" = "8:_B145E5EB173145D699545451BD2BAD93.0862028596DF4668AB1D736D2B40424F"
-                    "DefaultValue" = "8:_B145E5EB173145D699545451BD2BAD93.0862028596DF4668AB1D736D2B40424F"
+                    "Value" = "8:_2E378C60DB144793BE361E98417441BE.0862028596DF4668AB1D736D2B40424F"
+                    "DefaultValue" = "8:_2E378C60DB144793BE361E98417441BE.0862028596DF4668AB1D736D2B40424F"
                     "ParentName" = "8:_BE7C8A748AB042DFB3B17E4D4E332955.0862028596DF4668AB1D736D2B40424F"
                     "UsePlugInResources" = "11:FALSE"
                     }
@@ -3486,6 +3122,20 @@
                     "Setting" = "3:2"
                     "Value" = "8:_3A68CC4A547B4A2BBD68333F59F4F0F5.0862028596DF4668AB1D736D2B40424F"
                     "DefaultValue" = "8:_3A68CC4A547B4A2BBD68333F59F4F0F5.0862028596DF4668AB1D736D2B40424F"
+                    "ParentName" = "8:_BE7C8A748AB042DFB3B17E4D4E332955.0862028596DF4668AB1D736D2B40424F"
+                    "UsePlugInResources" = "11:FALSE"
+                    }
+                    "_DD868092A7F59771E11BD6904D50961D.0862028596DF4668AB1D736D2B40424F"
+                    {
+                    "Name" = "8:_DD868092A7F59771E11BD6904D50961D.0862028596DF4668AB1D736D2B40424F"
+                    "DisplayName" = "8:"
+                    "Description" = "8:"
+                    "Type" = "3:2"
+                    "ContextData" = "8:InstallToGAC=;IsolateToManifest=_0486756ACBA2850EE9D54DEA4841C1EE.0862028596DF4668AB1D736D2B40424F"
+                    "Attributes" = "3:0"
+                    "Setting" = "3:2"
+                    "Value" = "8:_0486756ACBA2850EE9D54DEA4841C1EE.0862028596DF4668AB1D736D2B40424F"
+                    "DefaultValue" = "8:_0486756ACBA2850EE9D54DEA4841C1EE.0862028596DF4668AB1D736D2B40424F"
                     "ParentName" = "8:_BE7C8A748AB042DFB3B17E4D4E332955.0862028596DF4668AB1D736D2B40424F"
                     "UsePlugInResources" = "11:FALSE"
                     }
@@ -3643,20 +3293,6 @@
                     "ParentName" = "8:_BE7C8A748AB042DFB3B17E4D4E332955.0862028596DF4668AB1D736D2B40424F"
                     "UsePlugInResources" = "11:FALSE"
                     }
-                    "_F1029C1DF2BBD8F5DB12088B96B3F676.0862028596DF4668AB1D736D2B40424F"
-                    {
-                    "Name" = "8:_F1029C1DF2BBD8F5DB12088B96B3F676.0862028596DF4668AB1D736D2B40424F"
-                    "DisplayName" = "8:"
-                    "Description" = "8:"
-                    "Type" = "3:2"
-                    "ContextData" = "8:InstallToGAC=;IsolateToManifest=_2BAC679FA2284860971D6C050FA4E76A.0862028596DF4668AB1D736D2B40424F"
-                    "Attributes" = "3:0"
-                    "Setting" = "3:2"
-                    "Value" = "8:_2BAC679FA2284860971D6C050FA4E76A.0862028596DF4668AB1D736D2B40424F"
-                    "DefaultValue" = "8:_2BAC679FA2284860971D6C050FA4E76A.0862028596DF4668AB1D736D2B40424F"
-                    "ParentName" = "8:_BE7C8A748AB042DFB3B17E4D4E332955.0862028596DF4668AB1D736D2B40424F"
-                    "UsePlugInResources" = "11:FALSE"
-                    }
                     "_F24F9EF8DFADAC89AA953BD37FBF84C8.0862028596DF4668AB1D736D2B40424F"
                     {
                     "Name" = "8:_F24F9EF8DFADAC89AA953BD37FBF84C8.0862028596DF4668AB1D736D2B40424F"
@@ -3699,20 +3335,6 @@
                     "ParentName" = "8:_BE7C8A748AB042DFB3B17E4D4E332955.0862028596DF4668AB1D736D2B40424F"
                     "UsePlugInResources" = "11:FALSE"
                     }
-                    "_F4253BFFE0BD51DC7A74F399CF748E0B.0862028596DF4668AB1D736D2B40424F"
-                    {
-                    "Name" = "8:_F4253BFFE0BD51DC7A74F399CF748E0B.0862028596DF4668AB1D736D2B40424F"
-                    "DisplayName" = "8:"
-                    "Description" = "8:"
-                    "Type" = "3:2"
-                    "ContextData" = "8:InstallToGAC=;IsolateToManifest=_408793932C71490182C1AA0A07D08EA0.0862028596DF4668AB1D736D2B40424F"
-                    "Attributes" = "3:0"
-                    "Setting" = "3:2"
-                    "Value" = "8:_408793932C71490182C1AA0A07D08EA0.0862028596DF4668AB1D736D2B40424F"
-                    "DefaultValue" = "8:_408793932C71490182C1AA0A07D08EA0.0862028596DF4668AB1D736D2B40424F"
-                    "ParentName" = "8:_BE7C8A748AB042DFB3B17E4D4E332955.0862028596DF4668AB1D736D2B40424F"
-                    "UsePlugInResources" = "11:FALSE"
-                    }
                     "_F50D24D0ACFB5F4A68C4B6EB9A369FC3.0862028596DF4668AB1D736D2B40424F"
                     {
                     "Name" = "8:_F50D24D0ACFB5F4A68C4B6EB9A369FC3.0862028596DF4668AB1D736D2B40424F"
@@ -3738,20 +3360,6 @@
                     "Setting" = "3:2"
                     "Value" = "8:_62236F02AEDE43F2A978E2F6B4E381EB.0862028596DF4668AB1D736D2B40424F"
                     "DefaultValue" = "8:_62236F02AEDE43F2A978E2F6B4E381EB.0862028596DF4668AB1D736D2B40424F"
-                    "ParentName" = "8:_BE7C8A748AB042DFB3B17E4D4E332955.0862028596DF4668AB1D736D2B40424F"
-                    "UsePlugInResources" = "11:FALSE"
-                    }
-                    "_F976B09D6BEE75C02117E3EB46FD2A5E.0862028596DF4668AB1D736D2B40424F"
-                    {
-                    "Name" = "8:_F976B09D6BEE75C02117E3EB46FD2A5E.0862028596DF4668AB1D736D2B40424F"
-                    "DisplayName" = "8:"
-                    "Description" = "8:"
-                    "Type" = "3:2"
-                    "ContextData" = "8:InstallToGAC=;IsolateToManifest=_4FB2C7F2E91A45D7A13DDDCCD335FEDB.0862028596DF4668AB1D736D2B40424F"
-                    "Attributes" = "3:0"
-                    "Setting" = "3:2"
-                    "Value" = "8:_4FB2C7F2E91A45D7A13DDDCCD335FEDB.0862028596DF4668AB1D736D2B40424F"
-                    "DefaultValue" = "8:_4FB2C7F2E91A45D7A13DDDCCD335FEDB.0862028596DF4668AB1D736D2B40424F"
                     "ParentName" = "8:_BE7C8A748AB042DFB3B17E4D4E332955.0862028596DF4668AB1D736D2B40424F"
                     "UsePlugInResources" = "11:FALSE"
                     }

--- a/Installers/Setup x86/Setup x86.vdproj
+++ b/Installers/Setup x86/Setup x86.vdproj
@@ -67,6 +67,12 @@
         "OwnerKey" = "8:_F2A1C12D9CF7474E8D9C0D5085B01B98"
         "MsmSig" = "8:_UNDEFINED"
         }
+        "Entry"
+        {
+        "MsmKey" = "8:_UNDEFINED"
+        "OwnerKey" = "8:_C76928219DA049F58E9E2F3BE7D714E8"
+        "MsmSig" = "8:_UNDEFINED"
+        }
     }
     "Configurations"
     {
@@ -280,7 +286,7 @@
             {
             "AssemblyRegister" = "3:1"
             "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:CloudVeil, Version=1.6.15.0, Culture=neutral, processorArchitecture=x86"
+            "AssemblyAsmDisplayName" = "8:CloudVeil, Version=1.6.17.0, Culture=neutral, processorArchitecture=x86"
                 "ScatterAssemblies"
                 {
                     "_B5A0B65E2A4D47A3AB04F6282687850B"
@@ -394,15 +400,15 @@
         {
         "Name" = "8:Microsoft Visual Studio"
         "ProductName" = "8:CloudVeil For Windows"
-        "ProductCode" = "8:{B471AA36-AE07-4927-92AA-713AE1A167C4}"
-        "PackageCode" = "8:{642DC319-4CF4-4A0F-B34C-835816BF5838}"
+        "ProductCode" = "8:{58254FB8-B50B-4F85-972C-7EA1F431751A}"
+        "PackageCode" = "8:{779B336A-CD49-4407-B115-96610B2BD2BA}"
         "UpgradeCode" = "8:{57058EEC-162C-4D48-993E-4AE6095F66CA}"
         "AspNetVersion" = "8:4.0.30319.0"
         "RestartWWWService" = "11:FALSE"
         "RemovePreviousVersions" = "11:TRUE"
         "DetectNewerInstalledVersion" = "11:TRUE"
         "InstallAllUsers" = "11:TRUE"
-        "ProductVersion" = "8:1.6.16"
+        "ProductVersion" = "8:1.6.17"
         "Manufacturer" = "8:CloudVeil"
         "ARPHELPTELEPHONE" = "8:"
         "ARPHELPLINK" = "8:https://cloudveil.org"
@@ -1021,20 +1027,6 @@
                     "ParentName" = "8:_46E6D2F2ABA84935950C5B6504FA20EF.620CD2DC407F43B9916732C473EF22AC"
                     "UsePlugInResources" = "11:FALSE"
                     }
-                    "_02CFD473C2FE730480962F53AD91FB96.620CD2DC407F43B9916732C473EF22AC"
-                    {
-                    "Name" = "8:_02CFD473C2FE730480962F53AD91FB96.620CD2DC407F43B9916732C473EF22AC"
-                    "DisplayName" = "8:"
-                    "Description" = "8:"
-                    "Type" = "3:2"
-                    "ContextData" = "8:InstallToGAC=;IsolateToManifest=_1AE752308B5843B1A1C1ACAFE2EE8717.620CD2DC407F43B9916732C473EF22AC"
-                    "Attributes" = "3:0"
-                    "Setting" = "3:2"
-                    "Value" = "8:_1AE752308B5843B1A1C1ACAFE2EE8717.620CD2DC407F43B9916732C473EF22AC"
-                    "DefaultValue" = "8:_1AE752308B5843B1A1C1ACAFE2EE8717.620CD2DC407F43B9916732C473EF22AC"
-                    "ParentName" = "8:_46E6D2F2ABA84935950C5B6504FA20EF.620CD2DC407F43B9916732C473EF22AC"
-                    "UsePlugInResources" = "11:FALSE"
-                    }
                     "_03FF48C2BBDBAE4E87AC6C8922EBD29E.620CD2DC407F43B9916732C473EF22AC"
                     {
                     "Name" = "8:_03FF48C2BBDBAE4E87AC6C8922EBD29E.620CD2DC407F43B9916732C473EF22AC"
@@ -1105,20 +1097,6 @@
                     "ParentName" = "8:_46E6D2F2ABA84935950C5B6504FA20EF.620CD2DC407F43B9916732C473EF22AC"
                     "UsePlugInResources" = "11:FALSE"
                     }
-                    "_0EACBD301E2F28A2B285FE51A1BA4DE0.620CD2DC407F43B9916732C473EF22AC"
-                    {
-                    "Name" = "8:_0EACBD301E2F28A2B285FE51A1BA4DE0.620CD2DC407F43B9916732C473EF22AC"
-                    "DisplayName" = "8:"
-                    "Description" = "8:"
-                    "Type" = "3:2"
-                    "ContextData" = "8:InstallToGAC=;IsolateToManifest=_BF96AD1B4B644C95B866A5DFE34DA745.620CD2DC407F43B9916732C473EF22AC"
-                    "Attributes" = "3:0"
-                    "Setting" = "3:2"
-                    "Value" = "8:_BF96AD1B4B644C95B866A5DFE34DA745.620CD2DC407F43B9916732C473EF22AC"
-                    "DefaultValue" = "8:_BF96AD1B4B644C95B866A5DFE34DA745.620CD2DC407F43B9916732C473EF22AC"
-                    "ParentName" = "8:_46E6D2F2ABA84935950C5B6504FA20EF.620CD2DC407F43B9916732C473EF22AC"
-                    "UsePlugInResources" = "11:FALSE"
-                    }
                     "_0F230E86E9C8B62D0507B6FB1A15BDAA.620CD2DC407F43B9916732C473EF22AC"
                     {
                     "Name" = "8:_0F230E86E9C8B62D0507B6FB1A15BDAA.620CD2DC407F43B9916732C473EF22AC"
@@ -1130,20 +1108,6 @@
                     "Setting" = "3:2"
                     "Value" = "8:_370D39C8EEA94040A0B44DFE59959303.620CD2DC407F43B9916732C473EF22AC"
                     "DefaultValue" = "8:_370D39C8EEA94040A0B44DFE59959303.620CD2DC407F43B9916732C473EF22AC"
-                    "ParentName" = "8:_46E6D2F2ABA84935950C5B6504FA20EF.620CD2DC407F43B9916732C473EF22AC"
-                    "UsePlugInResources" = "11:FALSE"
-                    }
-                    "_0F412F4AC46F6623C458016B97AE9B54.620CD2DC407F43B9916732C473EF22AC"
-                    {
-                    "Name" = "8:_0F412F4AC46F6623C458016B97AE9B54.620CD2DC407F43B9916732C473EF22AC"
-                    "DisplayName" = "8:"
-                    "Description" = "8:"
-                    "Type" = "3:2"
-                    "ContextData" = "8:InstallToGAC=;IsolateToManifest=_53FEAD55559945F59ADD027804DC10D1.620CD2DC407F43B9916732C473EF22AC"
-                    "Attributes" = "3:0"
-                    "Setting" = "3:2"
-                    "Value" = "8:_53FEAD55559945F59ADD027804DC10D1.620CD2DC407F43B9916732C473EF22AC"
-                    "DefaultValue" = "8:_53FEAD55559945F59ADD027804DC10D1.620CD2DC407F43B9916732C473EF22AC"
                     "ParentName" = "8:_46E6D2F2ABA84935950C5B6504FA20EF.620CD2DC407F43B9916732C473EF22AC"
                     "UsePlugInResources" = "11:FALSE"
                     }
@@ -1200,20 +1164,6 @@
                     "Setting" = "3:2"
                     "Value" = "8:_18F3F0272FB54CCA8F4AFE780D8D5632.620CD2DC407F43B9916732C473EF22AC"
                     "DefaultValue" = "8:_18F3F0272FB54CCA8F4AFE780D8D5632.620CD2DC407F43B9916732C473EF22AC"
-                    "ParentName" = "8:_46E6D2F2ABA84935950C5B6504FA20EF.620CD2DC407F43B9916732C473EF22AC"
-                    "UsePlugInResources" = "11:FALSE"
-                    }
-                    "_1509F32B00CFB74DFDFCFD9DC672668A.620CD2DC407F43B9916732C473EF22AC"
-                    {
-                    "Name" = "8:_1509F32B00CFB74DFDFCFD9DC672668A.620CD2DC407F43B9916732C473EF22AC"
-                    "DisplayName" = "8:"
-                    "Description" = "8:"
-                    "Type" = "3:2"
-                    "ContextData" = "8:InstallToGAC=;IsolateToManifest=_D991585BB7224CB082D613AF498C0977.620CD2DC407F43B9916732C473EF22AC"
-                    "Attributes" = "3:0"
-                    "Setting" = "3:2"
-                    "Value" = "8:_D991585BB7224CB082D613AF498C0977.620CD2DC407F43B9916732C473EF22AC"
-                    "DefaultValue" = "8:_D991585BB7224CB082D613AF498C0977.620CD2DC407F43B9916732C473EF22AC"
                     "ParentName" = "8:_46E6D2F2ABA84935950C5B6504FA20EF.620CD2DC407F43B9916732C473EF22AC"
                     "UsePlugInResources" = "11:FALSE"
                     }
@@ -1525,20 +1475,6 @@
                     "ParentName" = "8:_46E6D2F2ABA84935950C5B6504FA20EF.620CD2DC407F43B9916732C473EF22AC"
                     "UsePlugInResources" = "11:FALSE"
                     }
-                    "_2CFE3611FFEE5A75BF72E181E0407C4D.620CD2DC407F43B9916732C473EF22AC"
-                    {
-                    "Name" = "8:_2CFE3611FFEE5A75BF72E181E0407C4D.620CD2DC407F43B9916732C473EF22AC"
-                    "DisplayName" = "8:"
-                    "Description" = "8:"
-                    "Type" = "3:2"
-                    "ContextData" = "8:InstallToGAC=;IsolateToManifest=_F8D317DA2A894416B727157E511BD2CC.620CD2DC407F43B9916732C473EF22AC"
-                    "Attributes" = "3:0"
-                    "Setting" = "3:2"
-                    "Value" = "8:_F8D317DA2A894416B727157E511BD2CC.620CD2DC407F43B9916732C473EF22AC"
-                    "DefaultValue" = "8:_F8D317DA2A894416B727157E511BD2CC.620CD2DC407F43B9916732C473EF22AC"
-                    "ParentName" = "8:_46E6D2F2ABA84935950C5B6504FA20EF.620CD2DC407F43B9916732C473EF22AC"
-                    "UsePlugInResources" = "11:FALSE"
-                    }
                     "_2EA2F578271E5645152242CB1510B0D9.620CD2DC407F43B9916732C473EF22AC"
                     {
                     "Name" = "8:_2EA2F578271E5645152242CB1510B0D9.620CD2DC407F43B9916732C473EF22AC"
@@ -1578,20 +1514,6 @@
                     "Setting" = "3:2"
                     "Value" = "8:_0CC9722712624DD7A86BBB9D9D0E15D8.620CD2DC407F43B9916732C473EF22AC"
                     "DefaultValue" = "8:_0CC9722712624DD7A86BBB9D9D0E15D8.620CD2DC407F43B9916732C473EF22AC"
-                    "ParentName" = "8:_46E6D2F2ABA84935950C5B6504FA20EF.620CD2DC407F43B9916732C473EF22AC"
-                    "UsePlugInResources" = "11:FALSE"
-                    }
-                    "_30E13E79BA8541FB6C68E6BA44E4F757.620CD2DC407F43B9916732C473EF22AC"
-                    {
-                    "Name" = "8:_30E13E79BA8541FB6C68E6BA44E4F757.620CD2DC407F43B9916732C473EF22AC"
-                    "DisplayName" = "8:"
-                    "Description" = "8:"
-                    "Type" = "3:2"
-                    "ContextData" = "8:InstallToGAC=;IsolateToManifest=_A74A4BD695F24F3AB321631E8F344E20.620CD2DC407F43B9916732C473EF22AC"
-                    "Attributes" = "3:0"
-                    "Setting" = "3:2"
-                    "Value" = "8:_A74A4BD695F24F3AB321631E8F344E20.620CD2DC407F43B9916732C473EF22AC"
-                    "DefaultValue" = "8:_A74A4BD695F24F3AB321631E8F344E20.620CD2DC407F43B9916732C473EF22AC"
                     "ParentName" = "8:_46E6D2F2ABA84935950C5B6504FA20EF.620CD2DC407F43B9916732C473EF22AC"
                     "UsePlugInResources" = "11:FALSE"
                     }
@@ -1707,6 +1629,20 @@
                     "ParentName" = "8:_46E6D2F2ABA84935950C5B6504FA20EF.620CD2DC407F43B9916732C473EF22AC"
                     "UsePlugInResources" = "11:FALSE"
                     }
+                    "_3A6F3F17B5355CF730EAEE8E5B072AB1.620CD2DC407F43B9916732C473EF22AC"
+                    {
+                    "Name" = "8:_3A6F3F17B5355CF730EAEE8E5B072AB1.620CD2DC407F43B9916732C473EF22AC"
+                    "DisplayName" = "8:"
+                    "Description" = "8:"
+                    "Type" = "3:2"
+                    "ContextData" = "8:InstallToGAC=;IsolateToManifest=_C92B50C16A0922217FD48D26C47C0DC5.620CD2DC407F43B9916732C473EF22AC"
+                    "Attributes" = "3:0"
+                    "Setting" = "3:2"
+                    "Value" = "8:_C92B50C16A0922217FD48D26C47C0DC5.620CD2DC407F43B9916732C473EF22AC"
+                    "DefaultValue" = "8:_C92B50C16A0922217FD48D26C47C0DC5.620CD2DC407F43B9916732C473EF22AC"
+                    "ParentName" = "8:_46E6D2F2ABA84935950C5B6504FA20EF.620CD2DC407F43B9916732C473EF22AC"
+                    "UsePlugInResources" = "11:FALSE"
+                    }
                     "_3B7B2DD3DCC701F81BF07745C324CE35.620CD2DC407F43B9916732C473EF22AC"
                     {
                     "Name" = "8:_3B7B2DD3DCC701F81BF07745C324CE35.620CD2DC407F43B9916732C473EF22AC"
@@ -1805,17 +1741,17 @@
                     "ParentName" = "8:_46E6D2F2ABA84935950C5B6504FA20EF.620CD2DC407F43B9916732C473EF22AC"
                     "UsePlugInResources" = "11:FALSE"
                     }
-                    "_425CD228B1771F8BAFD71AB71DB7516D.620CD2DC407F43B9916732C473EF22AC"
+                    "_456776AE473C038458190AB768886762.620CD2DC407F43B9916732C473EF22AC"
                     {
-                    "Name" = "8:_425CD228B1771F8BAFD71AB71DB7516D.620CD2DC407F43B9916732C473EF22AC"
+                    "Name" = "8:_456776AE473C038458190AB768886762.620CD2DC407F43B9916732C473EF22AC"
                     "DisplayName" = "8:"
                     "Description" = "8:"
                     "Type" = "3:2"
-                    "ContextData" = "8:InstallToGAC=;IsolateToManifest=_09AEB2E2F5F54101AED7BA81C89EB8BD.620CD2DC407F43B9916732C473EF22AC"
+                    "ContextData" = "8:InstallToGAC=;IsolateToManifest=_6C4AE007196B44C0B60FE94353DEFEA3.620CD2DC407F43B9916732C473EF22AC"
                     "Attributes" = "3:0"
                     "Setting" = "3:2"
-                    "Value" = "8:_09AEB2E2F5F54101AED7BA81C89EB8BD.620CD2DC407F43B9916732C473EF22AC"
-                    "DefaultValue" = "8:_09AEB2E2F5F54101AED7BA81C89EB8BD.620CD2DC407F43B9916732C473EF22AC"
+                    "Value" = "8:_6C4AE007196B44C0B60FE94353DEFEA3.620CD2DC407F43B9916732C473EF22AC"
+                    "DefaultValue" = "8:_6C4AE007196B44C0B60FE94353DEFEA3.620CD2DC407F43B9916732C473EF22AC"
                     "ParentName" = "8:_46E6D2F2ABA84935950C5B6504FA20EF.620CD2DC407F43B9916732C473EF22AC"
                     "UsePlugInResources" = "11:FALSE"
                     }
@@ -1942,6 +1878,20 @@
                     "ParentName" = "8:_46E6D2F2ABA84935950C5B6504FA20EF.620CD2DC407F43B9916732C473EF22AC"
                     "UsePlugInResources" = "11:FALSE"
                     }
+                    "_517A9EF38F67747F987EA714475DC313.620CD2DC407F43B9916732C473EF22AC"
+                    {
+                    "Name" = "8:_517A9EF38F67747F987EA714475DC313.620CD2DC407F43B9916732C473EF22AC"
+                    "DisplayName" = "8:"
+                    "Description" = "8:"
+                    "Type" = "3:2"
+                    "ContextData" = "8:InstallToGAC=;IsolateToManifest=_554CEF6F3EE749E7AD153E33FFCFA842.620CD2DC407F43B9916732C473EF22AC"
+                    "Attributes" = "3:0"
+                    "Setting" = "3:2"
+                    "Value" = "8:_554CEF6F3EE749E7AD153E33FFCFA842.620CD2DC407F43B9916732C473EF22AC"
+                    "DefaultValue" = "8:_554CEF6F3EE749E7AD153E33FFCFA842.620CD2DC407F43B9916732C473EF22AC"
+                    "ParentName" = "8:_46E6D2F2ABA84935950C5B6504FA20EF.620CD2DC407F43B9916732C473EF22AC"
+                    "UsePlugInResources" = "11:FALSE"
+                    }
                     "_542C4C4B5F82416FF346A46E8E1E80E8.620CD2DC407F43B9916732C473EF22AC"
                     {
                     "Name" = "8:_542C4C4B5F82416FF346A46E8E1E80E8.620CD2DC407F43B9916732C473EF22AC"
@@ -1956,31 +1906,17 @@
                     "ParentName" = "8:_46E6D2F2ABA84935950C5B6504FA20EF.620CD2DC407F43B9916732C473EF22AC"
                     "UsePlugInResources" = "11:FALSE"
                     }
-                    "_555B63FD9EB0D00A6EEBF72E69191414.620CD2DC407F43B9916732C473EF22AC"
+                    "_550B59281090292C70478C2B3B91FA86.620CD2DC407F43B9916732C473EF22AC"
                     {
-                    "Name" = "8:_555B63FD9EB0D00A6EEBF72E69191414.620CD2DC407F43B9916732C473EF22AC"
+                    "Name" = "8:_550B59281090292C70478C2B3B91FA86.620CD2DC407F43B9916732C473EF22AC"
                     "DisplayName" = "8:"
                     "Description" = "8:"
                     "Type" = "3:2"
-                    "ContextData" = "8:InstallToGAC=;IsolateToManifest=_8CD6855B20004E5A869D5483C491493E.620CD2DC407F43B9916732C473EF22AC"
+                    "ContextData" = "8:InstallToGAC=;IsolateToManifest=_9391778E8ECA43DCBE5E2685D59CFA59.620CD2DC407F43B9916732C473EF22AC"
                     "Attributes" = "3:0"
                     "Setting" = "3:2"
-                    "Value" = "8:_8CD6855B20004E5A869D5483C491493E.620CD2DC407F43B9916732C473EF22AC"
-                    "DefaultValue" = "8:_8CD6855B20004E5A869D5483C491493E.620CD2DC407F43B9916732C473EF22AC"
-                    "ParentName" = "8:_46E6D2F2ABA84935950C5B6504FA20EF.620CD2DC407F43B9916732C473EF22AC"
-                    "UsePlugInResources" = "11:FALSE"
-                    }
-                    "_580463CFD4E4A2006F9CBA5F63C59B68.620CD2DC407F43B9916732C473EF22AC"
-                    {
-                    "Name" = "8:_580463CFD4E4A2006F9CBA5F63C59B68.620CD2DC407F43B9916732C473EF22AC"
-                    "DisplayName" = "8:"
-                    "Description" = "8:"
-                    "Type" = "3:2"
-                    "ContextData" = "8:InstallToGAC=;IsolateToManifest=_A3391743662F444B878C95E8DF8B1C3C.620CD2DC407F43B9916732C473EF22AC"
-                    "Attributes" = "3:0"
-                    "Setting" = "3:2"
-                    "Value" = "8:_A3391743662F444B878C95E8DF8B1C3C.620CD2DC407F43B9916732C473EF22AC"
-                    "DefaultValue" = "8:_A3391743662F444B878C95E8DF8B1C3C.620CD2DC407F43B9916732C473EF22AC"
+                    "Value" = "8:_9391778E8ECA43DCBE5E2685D59CFA59.620CD2DC407F43B9916732C473EF22AC"
+                    "DefaultValue" = "8:_9391778E8ECA43DCBE5E2685D59CFA59.620CD2DC407F43B9916732C473EF22AC"
                     "ParentName" = "8:_46E6D2F2ABA84935950C5B6504FA20EF.620CD2DC407F43B9916732C473EF22AC"
                     "UsePlugInResources" = "11:FALSE"
                     }
@@ -2082,31 +2018,17 @@
                     "ParentName" = "8:_46E6D2F2ABA84935950C5B6504FA20EF.620CD2DC407F43B9916732C473EF22AC"
                     "UsePlugInResources" = "11:FALSE"
                     }
-                    "_5E87A08A79F47AF8C6D7BB3DE3C4D538.620CD2DC407F43B9916732C473EF22AC"
+                    "_6113FE252DB4EA19DA8590FFCE681746.620CD2DC407F43B9916732C473EF22AC"
                     {
-                    "Name" = "8:_5E87A08A79F47AF8C6D7BB3DE3C4D538.620CD2DC407F43B9916732C473EF22AC"
+                    "Name" = "8:_6113FE252DB4EA19DA8590FFCE681746.620CD2DC407F43B9916732C473EF22AC"
                     "DisplayName" = "8:"
                     "Description" = "8:"
                     "Type" = "3:2"
-                    "ContextData" = "8:InstallToGAC=;IsolateToManifest=_036A10B2F4F8446396374D4A43A015DE.620CD2DC407F43B9916732C473EF22AC"
+                    "ContextData" = "8:InstallToGAC=;IsolateToManifest=_814918A385CB4A4C81943B8FEDFF6401.620CD2DC407F43B9916732C473EF22AC"
                     "Attributes" = "3:0"
                     "Setting" = "3:2"
-                    "Value" = "8:_036A10B2F4F8446396374D4A43A015DE.620CD2DC407F43B9916732C473EF22AC"
-                    "DefaultValue" = "8:_036A10B2F4F8446396374D4A43A015DE.620CD2DC407F43B9916732C473EF22AC"
-                    "ParentName" = "8:_46E6D2F2ABA84935950C5B6504FA20EF.620CD2DC407F43B9916732C473EF22AC"
-                    "UsePlugInResources" = "11:FALSE"
-                    }
-                    "_6217D52BBD886B42EE4D642242F67DE3.620CD2DC407F43B9916732C473EF22AC"
-                    {
-                    "Name" = "8:_6217D52BBD886B42EE4D642242F67DE3.620CD2DC407F43B9916732C473EF22AC"
-                    "DisplayName" = "8:"
-                    "Description" = "8:"
-                    "Type" = "3:2"
-                    "ContextData" = "8:InstallToGAC=;IsolateToManifest=_685AB38824E74D72BE8F321896C8A0D5.620CD2DC407F43B9916732C473EF22AC"
-                    "Attributes" = "3:0"
-                    "Setting" = "3:2"
-                    "Value" = "8:_685AB38824E74D72BE8F321896C8A0D5.620CD2DC407F43B9916732C473EF22AC"
-                    "DefaultValue" = "8:_685AB38824E74D72BE8F321896C8A0D5.620CD2DC407F43B9916732C473EF22AC"
+                    "Value" = "8:_814918A385CB4A4C81943B8FEDFF6401.620CD2DC407F43B9916732C473EF22AC"
+                    "DefaultValue" = "8:_814918A385CB4A4C81943B8FEDFF6401.620CD2DC407F43B9916732C473EF22AC"
                     "ParentName" = "8:_46E6D2F2ABA84935950C5B6504FA20EF.620CD2DC407F43B9916732C473EF22AC"
                     "UsePlugInResources" = "11:FALSE"
                     }
@@ -2121,20 +2043,6 @@
                     "Setting" = "3:2"
                     "Value" = "8:_D95227983FA140FEA06CE12523F8189B.620CD2DC407F43B9916732C473EF22AC"
                     "DefaultValue" = "8:_D95227983FA140FEA06CE12523F8189B.620CD2DC407F43B9916732C473EF22AC"
-                    "ParentName" = "8:_46E6D2F2ABA84935950C5B6504FA20EF.620CD2DC407F43B9916732C473EF22AC"
-                    "UsePlugInResources" = "11:FALSE"
-                    }
-                    "_623935263BC7AD43601C4A6C7C0942B1.620CD2DC407F43B9916732C473EF22AC"
-                    {
-                    "Name" = "8:_623935263BC7AD43601C4A6C7C0942B1.620CD2DC407F43B9916732C473EF22AC"
-                    "DisplayName" = "8:"
-                    "Description" = "8:"
-                    "Type" = "3:2"
-                    "ContextData" = "8:InstallToGAC=;IsolateToManifest=_EDE3E1A69D5A45249FFBBF72F57779CC.620CD2DC407F43B9916732C473EF22AC"
-                    "Attributes" = "3:0"
-                    "Setting" = "3:2"
-                    "Value" = "8:_EDE3E1A69D5A45249FFBBF72F57779CC.620CD2DC407F43B9916732C473EF22AC"
-                    "DefaultValue" = "8:_EDE3E1A69D5A45249FFBBF72F57779CC.620CD2DC407F43B9916732C473EF22AC"
                     "ParentName" = "8:_46E6D2F2ABA84935950C5B6504FA20EF.620CD2DC407F43B9916732C473EF22AC"
                     "UsePlugInResources" = "11:FALSE"
                     }
@@ -2208,34 +2116,6 @@
                     "ParentName" = "8:_46E6D2F2ABA84935950C5B6504FA20EF.620CD2DC407F43B9916732C473EF22AC"
                     "UsePlugInResources" = "11:FALSE"
                     }
-                    "_6D6186C7A4E8ADE9E17BEB38F654120B.620CD2DC407F43B9916732C473EF22AC"
-                    {
-                    "Name" = "8:_6D6186C7A4E8ADE9E17BEB38F654120B.620CD2DC407F43B9916732C473EF22AC"
-                    "DisplayName" = "8:"
-                    "Description" = "8:"
-                    "Type" = "3:2"
-                    "ContextData" = "8:InstallToGAC=;IsolateToManifest=_5B1DA42DB46745B5AD4BFCEAEF19C71C.620CD2DC407F43B9916732C473EF22AC"
-                    "Attributes" = "3:0"
-                    "Setting" = "3:2"
-                    "Value" = "8:_5B1DA42DB46745B5AD4BFCEAEF19C71C.620CD2DC407F43B9916732C473EF22AC"
-                    "DefaultValue" = "8:_5B1DA42DB46745B5AD4BFCEAEF19C71C.620CD2DC407F43B9916732C473EF22AC"
-                    "ParentName" = "8:_46E6D2F2ABA84935950C5B6504FA20EF.620CD2DC407F43B9916732C473EF22AC"
-                    "UsePlugInResources" = "11:FALSE"
-                    }
-                    "_787A1DA4023E506BFA39BD06CD6ED291.620CD2DC407F43B9916732C473EF22AC"
-                    {
-                    "Name" = "8:_787A1DA4023E506BFA39BD06CD6ED291.620CD2DC407F43B9916732C473EF22AC"
-                    "DisplayName" = "8:"
-                    "Description" = "8:"
-                    "Type" = "3:2"
-                    "ContextData" = "8:InstallToGAC=;IsolateToManifest=_9B0FBC01BF8A4C4F983C755622112E5B.620CD2DC407F43B9916732C473EF22AC"
-                    "Attributes" = "3:0"
-                    "Setting" = "3:2"
-                    "Value" = "8:_9B0FBC01BF8A4C4F983C755622112E5B.620CD2DC407F43B9916732C473EF22AC"
-                    "DefaultValue" = "8:_9B0FBC01BF8A4C4F983C755622112E5B.620CD2DC407F43B9916732C473EF22AC"
-                    "ParentName" = "8:_46E6D2F2ABA84935950C5B6504FA20EF.620CD2DC407F43B9916732C473EF22AC"
-                    "UsePlugInResources" = "11:FALSE"
-                    }
                     "_787A6BC659AA4A6900FCB42FE9119B17.620CD2DC407F43B9916732C473EF22AC"
                     {
                     "Name" = "8:_787A6BC659AA4A6900FCB42FE9119B17.620CD2DC407F43B9916732C473EF22AC"
@@ -2306,20 +2186,6 @@
                     "ParentName" = "8:_46E6D2F2ABA84935950C5B6504FA20EF.620CD2DC407F43B9916732C473EF22AC"
                     "UsePlugInResources" = "11:FALSE"
                     }
-                    "_7FED1649421381E3F23D5B76F866E405.620CD2DC407F43B9916732C473EF22AC"
-                    {
-                    "Name" = "8:_7FED1649421381E3F23D5B76F866E405.620CD2DC407F43B9916732C473EF22AC"
-                    "DisplayName" = "8:"
-                    "Description" = "8:"
-                    "Type" = "3:2"
-                    "ContextData" = "8:InstallToGAC=;IsolateToManifest=_94635D6407D74ABB97975368AE78FB2C.620CD2DC407F43B9916732C473EF22AC"
-                    "Attributes" = "3:0"
-                    "Setting" = "3:2"
-                    "Value" = "8:_94635D6407D74ABB97975368AE78FB2C.620CD2DC407F43B9916732C473EF22AC"
-                    "DefaultValue" = "8:_94635D6407D74ABB97975368AE78FB2C.620CD2DC407F43B9916732C473EF22AC"
-                    "ParentName" = "8:_46E6D2F2ABA84935950C5B6504FA20EF.620CD2DC407F43B9916732C473EF22AC"
-                    "UsePlugInResources" = "11:FALSE"
-                    }
                     "_8472788B18E3366E5E7DD993700DF769.620CD2DC407F43B9916732C473EF22AC"
                     {
                     "Name" = "8:_8472788B18E3366E5E7DD993700DF769.620CD2DC407F43B9916732C473EF22AC"
@@ -2345,20 +2211,6 @@
                     "Setting" = "3:2"
                     "Value" = "8:_D803F994BA1543CAB5D220460ADD3835.620CD2DC407F43B9916732C473EF22AC"
                     "DefaultValue" = "8:_D803F994BA1543CAB5D220460ADD3835.620CD2DC407F43B9916732C473EF22AC"
-                    "ParentName" = "8:_46E6D2F2ABA84935950C5B6504FA20EF.620CD2DC407F43B9916732C473EF22AC"
-                    "UsePlugInResources" = "11:FALSE"
-                    }
-                    "_86E93AEE2C69BA39F3A86B68C881E50A.620CD2DC407F43B9916732C473EF22AC"
-                    {
-                    "Name" = "8:_86E93AEE2C69BA39F3A86B68C881E50A.620CD2DC407F43B9916732C473EF22AC"
-                    "DisplayName" = "8:"
-                    "Description" = "8:"
-                    "Type" = "3:2"
-                    "ContextData" = "8:InstallToGAC=;IsolateToManifest=_BB66A6EC7ADA44F7AF10FDA0EC73B8D9.620CD2DC407F43B9916732C473EF22AC"
-                    "Attributes" = "3:0"
-                    "Setting" = "3:2"
-                    "Value" = "8:_BB66A6EC7ADA44F7AF10FDA0EC73B8D9.620CD2DC407F43B9916732C473EF22AC"
-                    "DefaultValue" = "8:_BB66A6EC7ADA44F7AF10FDA0EC73B8D9.620CD2DC407F43B9916732C473EF22AC"
                     "ParentName" = "8:_46E6D2F2ABA84935950C5B6504FA20EF.620CD2DC407F43B9916732C473EF22AC"
                     "UsePlugInResources" = "11:FALSE"
                     }
@@ -2418,34 +2270,6 @@
                     "ParentName" = "8:_46E6D2F2ABA84935950C5B6504FA20EF.620CD2DC407F43B9916732C473EF22AC"
                     "UsePlugInResources" = "11:FALSE"
                     }
-                    "_8EAFA75AD89747FCBBB9A086C5BB1AD5.620CD2DC407F43B9916732C473EF22AC"
-                    {
-                    "Name" = "8:_8EAFA75AD89747FCBBB9A086C5BB1AD5.620CD2DC407F43B9916732C473EF22AC"
-                    "DisplayName" = "8:"
-                    "Description" = "8:"
-                    "Type" = "3:2"
-                    "ContextData" = "8:InstallToGAC=;IsolateToManifest=_504A860032BF411FAD81262B7E28F9DD.620CD2DC407F43B9916732C473EF22AC"
-                    "Attributes" = "3:0"
-                    "Setting" = "3:2"
-                    "Value" = "8:_504A860032BF411FAD81262B7E28F9DD.620CD2DC407F43B9916732C473EF22AC"
-                    "DefaultValue" = "8:_504A860032BF411FAD81262B7E28F9DD.620CD2DC407F43B9916732C473EF22AC"
-                    "ParentName" = "8:_46E6D2F2ABA84935950C5B6504FA20EF.620CD2DC407F43B9916732C473EF22AC"
-                    "UsePlugInResources" = "11:FALSE"
-                    }
-                    "_8FE53FC847345C4727F7797CBE4A1DAD.620CD2DC407F43B9916732C473EF22AC"
-                    {
-                    "Name" = "8:_8FE53FC847345C4727F7797CBE4A1DAD.620CD2DC407F43B9916732C473EF22AC"
-                    "DisplayName" = "8:"
-                    "Description" = "8:"
-                    "Type" = "3:2"
-                    "ContextData" = "8:InstallToGAC=;IsolateToManifest=_E797DD36EA14483C8C52D7C1F0560655.620CD2DC407F43B9916732C473EF22AC"
-                    "Attributes" = "3:0"
-                    "Setting" = "3:2"
-                    "Value" = "8:_E797DD36EA14483C8C52D7C1F0560655.620CD2DC407F43B9916732C473EF22AC"
-                    "DefaultValue" = "8:_E797DD36EA14483C8C52D7C1F0560655.620CD2DC407F43B9916732C473EF22AC"
-                    "ParentName" = "8:_46E6D2F2ABA84935950C5B6504FA20EF.620CD2DC407F43B9916732C473EF22AC"
-                    "UsePlugInResources" = "11:FALSE"
-                    }
                     "_93A2C1CC7C94DBA5A9D7C97C673488F7.620CD2DC407F43B9916732C473EF22AC"
                     {
                     "Name" = "8:_93A2C1CC7C94DBA5A9D7C97C673488F7.620CD2DC407F43B9916732C473EF22AC"
@@ -2471,6 +2295,20 @@
                     "Setting" = "3:2"
                     "Value" = "8:_6D9855CEE2724A47893BF620E27123E0.620CD2DC407F43B9916732C473EF22AC"
                     "DefaultValue" = "8:_6D9855CEE2724A47893BF620E27123E0.620CD2DC407F43B9916732C473EF22AC"
+                    "ParentName" = "8:_46E6D2F2ABA84935950C5B6504FA20EF.620CD2DC407F43B9916732C473EF22AC"
+                    "UsePlugInResources" = "11:FALSE"
+                    }
+                    "_952D8FB1811B1A2D81FC84C2C82AF0C6.620CD2DC407F43B9916732C473EF22AC"
+                    {
+                    "Name" = "8:_952D8FB1811B1A2D81FC84C2C82AF0C6.620CD2DC407F43B9916732C473EF22AC"
+                    "DisplayName" = "8:"
+                    "Description" = "8:"
+                    "Type" = "3:2"
+                    "ContextData" = "8:InstallToGAC=;IsolateToManifest=_E01B3BA21C454A9E95C02B2B2ED686DF.620CD2DC407F43B9916732C473EF22AC"
+                    "Attributes" = "3:0"
+                    "Setting" = "3:2"
+                    "Value" = "8:_E01B3BA21C454A9E95C02B2B2ED686DF.620CD2DC407F43B9916732C473EF22AC"
+                    "DefaultValue" = "8:_E01B3BA21C454A9E95C02B2B2ED686DF.620CD2DC407F43B9916732C473EF22AC"
                     "ParentName" = "8:_46E6D2F2ABA84935950C5B6504FA20EF.620CD2DC407F43B9916732C473EF22AC"
                     "UsePlugInResources" = "11:FALSE"
                     }
@@ -2586,20 +2424,6 @@
                     "ParentName" = "8:_46E6D2F2ABA84935950C5B6504FA20EF.620CD2DC407F43B9916732C473EF22AC"
                     "UsePlugInResources" = "11:FALSE"
                     }
-                    "_9F65E5A533A0387DC407361423B1830E.620CD2DC407F43B9916732C473EF22AC"
-                    {
-                    "Name" = "8:_9F65E5A533A0387DC407361423B1830E.620CD2DC407F43B9916732C473EF22AC"
-                    "DisplayName" = "8:"
-                    "Description" = "8:"
-                    "Type" = "3:2"
-                    "ContextData" = "8:InstallToGAC=;IsolateToManifest=_53EFD2DECF8B40E2BB6CF4BCCB6688BE.620CD2DC407F43B9916732C473EF22AC"
-                    "Attributes" = "3:0"
-                    "Setting" = "3:2"
-                    "Value" = "8:_53EFD2DECF8B40E2BB6CF4BCCB6688BE.620CD2DC407F43B9916732C473EF22AC"
-                    "DefaultValue" = "8:_53EFD2DECF8B40E2BB6CF4BCCB6688BE.620CD2DC407F43B9916732C473EF22AC"
-                    "ParentName" = "8:_46E6D2F2ABA84935950C5B6504FA20EF.620CD2DC407F43B9916732C473EF22AC"
-                    "UsePlugInResources" = "11:FALSE"
-                    }
                     "_A2B0BA80581FE82723DEBDBFFA2B82EB.620CD2DC407F43B9916732C473EF22AC"
                     {
                     "Name" = "8:_A2B0BA80581FE82723DEBDBFFA2B82EB.620CD2DC407F43B9916732C473EF22AC"
@@ -2642,20 +2466,6 @@
                     "ParentName" = "8:_46E6D2F2ABA84935950C5B6504FA20EF.620CD2DC407F43B9916732C473EF22AC"
                     "UsePlugInResources" = "11:FALSE"
                     }
-                    "_A44750148261BFE82D6A32971F269A76.620CD2DC407F43B9916732C473EF22AC"
-                    {
-                    "Name" = "8:_A44750148261BFE82D6A32971F269A76.620CD2DC407F43B9916732C473EF22AC"
-                    "DisplayName" = "8:"
-                    "Description" = "8:"
-                    "Type" = "3:2"
-                    "ContextData" = "8:InstallToGAC=;IsolateToManifest=_8B01F95B275B400585FA96F846BE6DE5.620CD2DC407F43B9916732C473EF22AC"
-                    "Attributes" = "3:0"
-                    "Setting" = "3:2"
-                    "Value" = "8:_8B01F95B275B400585FA96F846BE6DE5.620CD2DC407F43B9916732C473EF22AC"
-                    "DefaultValue" = "8:_8B01F95B275B400585FA96F846BE6DE5.620CD2DC407F43B9916732C473EF22AC"
-                    "ParentName" = "8:_46E6D2F2ABA84935950C5B6504FA20EF.620CD2DC407F43B9916732C473EF22AC"
-                    "UsePlugInResources" = "11:FALSE"
-                    }
                     "_A4BCE36ED9866726965E5B63E3A3B380.620CD2DC407F43B9916732C473EF22AC"
                     {
                     "Name" = "8:_A4BCE36ED9866726965E5B63E3A3B380.620CD2DC407F43B9916732C473EF22AC"
@@ -2681,34 +2491,6 @@
                     "Setting" = "3:2"
                     "Value" = "8:_F7FA00878B3A47E6BD32140D43CA3556.620CD2DC407F43B9916732C473EF22AC"
                     "DefaultValue" = "8:_F7FA00878B3A47E6BD32140D43CA3556.620CD2DC407F43B9916732C473EF22AC"
-                    "ParentName" = "8:_46E6D2F2ABA84935950C5B6504FA20EF.620CD2DC407F43B9916732C473EF22AC"
-                    "UsePlugInResources" = "11:FALSE"
-                    }
-                    "_A7ABA48EE66B5491BAD34297ABB75881.620CD2DC407F43B9916732C473EF22AC"
-                    {
-                    "Name" = "8:_A7ABA48EE66B5491BAD34297ABB75881.620CD2DC407F43B9916732C473EF22AC"
-                    "DisplayName" = "8:"
-                    "Description" = "8:"
-                    "Type" = "3:2"
-                    "ContextData" = "8:InstallToGAC=;IsolateToManifest=_E5C40EAEEC8C4FDF82F22294FBD02132.620CD2DC407F43B9916732C473EF22AC"
-                    "Attributes" = "3:0"
-                    "Setting" = "3:2"
-                    "Value" = "8:_E5C40EAEEC8C4FDF82F22294FBD02132.620CD2DC407F43B9916732C473EF22AC"
-                    "DefaultValue" = "8:_E5C40EAEEC8C4FDF82F22294FBD02132.620CD2DC407F43B9916732C473EF22AC"
-                    "ParentName" = "8:_46E6D2F2ABA84935950C5B6504FA20EF.620CD2DC407F43B9916732C473EF22AC"
-                    "UsePlugInResources" = "11:FALSE"
-                    }
-                    "_A9A19FFE6DA3BF981758793AAED080FC.620CD2DC407F43B9916732C473EF22AC"
-                    {
-                    "Name" = "8:_A9A19FFE6DA3BF981758793AAED080FC.620CD2DC407F43B9916732C473EF22AC"
-                    "DisplayName" = "8:"
-                    "Description" = "8:"
-                    "Type" = "3:2"
-                    "ContextData" = "8:InstallToGAC=;IsolateToManifest=_06894EAFDE5044F99D44A1A63EC73803.620CD2DC407F43B9916732C473EF22AC"
-                    "Attributes" = "3:0"
-                    "Setting" = "3:2"
-                    "Value" = "8:_06894EAFDE5044F99D44A1A63EC73803.620CD2DC407F43B9916732C473EF22AC"
-                    "DefaultValue" = "8:_06894EAFDE5044F99D44A1A63EC73803.620CD2DC407F43B9916732C473EF22AC"
                     "ParentName" = "8:_46E6D2F2ABA84935950C5B6504FA20EF.620CD2DC407F43B9916732C473EF22AC"
                     "UsePlugInResources" = "11:FALSE"
                     }
@@ -2768,20 +2550,6 @@
                     "ParentName" = "8:_46E6D2F2ABA84935950C5B6504FA20EF.620CD2DC407F43B9916732C473EF22AC"
                     "UsePlugInResources" = "11:FALSE"
                     }
-                    "_AE093638E2F3378A89DC7FD57AD710A0.620CD2DC407F43B9916732C473EF22AC"
-                    {
-                    "Name" = "8:_AE093638E2F3378A89DC7FD57AD710A0.620CD2DC407F43B9916732C473EF22AC"
-                    "DisplayName" = "8:"
-                    "Description" = "8:"
-                    "Type" = "3:2"
-                    "ContextData" = "8:InstallToGAC=;IsolateToManifest=_86DC139F541B45B897E2FDB7CFA4D039.620CD2DC407F43B9916732C473EF22AC"
-                    "Attributes" = "3:0"
-                    "Setting" = "3:2"
-                    "Value" = "8:_86DC139F541B45B897E2FDB7CFA4D039.620CD2DC407F43B9916732C473EF22AC"
-                    "DefaultValue" = "8:_86DC139F541B45B897E2FDB7CFA4D039.620CD2DC407F43B9916732C473EF22AC"
-                    "ParentName" = "8:_46E6D2F2ABA84935950C5B6504FA20EF.620CD2DC407F43B9916732C473EF22AC"
-                    "UsePlugInResources" = "11:FALSE"
-                    }
                     "_AE7B20ECC7DBAABE1AD3871BE94BB6D0.620CD2DC407F43B9916732C473EF22AC"
                     {
                     "Name" = "8:_AE7B20ECC7DBAABE1AD3871BE94BB6D0.620CD2DC407F43B9916732C473EF22AC"
@@ -2793,6 +2561,34 @@
                     "Setting" = "3:2"
                     "Value" = "8:_62D8421C143946AD861E9517194AADDB.620CD2DC407F43B9916732C473EF22AC"
                     "DefaultValue" = "8:_62D8421C143946AD861E9517194AADDB.620CD2DC407F43B9916732C473EF22AC"
+                    "ParentName" = "8:_46E6D2F2ABA84935950C5B6504FA20EF.620CD2DC407F43B9916732C473EF22AC"
+                    "UsePlugInResources" = "11:FALSE"
+                    }
+                    "_AEBE05BE4B4802595E42D368D9AB3032.620CD2DC407F43B9916732C473EF22AC"
+                    {
+                    "Name" = "8:_AEBE05BE4B4802595E42D368D9AB3032.620CD2DC407F43B9916732C473EF22AC"
+                    "DisplayName" = "8:"
+                    "Description" = "8:"
+                    "Type" = "3:2"
+                    "ContextData" = "8:InstallToGAC=;IsolateToManifest=_B239D98C3A834D9BBF5AD5226B17C459.620CD2DC407F43B9916732C473EF22AC"
+                    "Attributes" = "3:0"
+                    "Setting" = "3:2"
+                    "Value" = "8:_B239D98C3A834D9BBF5AD5226B17C459.620CD2DC407F43B9916732C473EF22AC"
+                    "DefaultValue" = "8:_B239D98C3A834D9BBF5AD5226B17C459.620CD2DC407F43B9916732C473EF22AC"
+                    "ParentName" = "8:_46E6D2F2ABA84935950C5B6504FA20EF.620CD2DC407F43B9916732C473EF22AC"
+                    "UsePlugInResources" = "11:FALSE"
+                    }
+                    "_AFC41E68A9E324956A17986332CB33CE.620CD2DC407F43B9916732C473EF22AC"
+                    {
+                    "Name" = "8:_AFC41E68A9E324956A17986332CB33CE.620CD2DC407F43B9916732C473EF22AC"
+                    "DisplayName" = "8:"
+                    "Description" = "8:"
+                    "Type" = "3:2"
+                    "ContextData" = "8:InstallToGAC=;IsolateToManifest=_1978EC9D741E4CF0B6846FBE73B2B9FA.620CD2DC407F43B9916732C473EF22AC"
+                    "Attributes" = "3:0"
+                    "Setting" = "3:2"
+                    "Value" = "8:_1978EC9D741E4CF0B6846FBE73B2B9FA.620CD2DC407F43B9916732C473EF22AC"
+                    "DefaultValue" = "8:_1978EC9D741E4CF0B6846FBE73B2B9FA.620CD2DC407F43B9916732C473EF22AC"
                     "ParentName" = "8:_46E6D2F2ABA84935950C5B6504FA20EF.620CD2DC407F43B9916732C473EF22AC"
                     "UsePlugInResources" = "11:FALSE"
                     }
@@ -3104,20 +2900,6 @@
                     "ParentName" = "8:_46E6D2F2ABA84935950C5B6504FA20EF.620CD2DC407F43B9916732C473EF22AC"
                     "UsePlugInResources" = "11:FALSE"
                     }
-                    "_BFE17C89CD0E95E4B99E560EE8941649.620CD2DC407F43B9916732C473EF22AC"
-                    {
-                    "Name" = "8:_BFE17C89CD0E95E4B99E560EE8941649.620CD2DC407F43B9916732C473EF22AC"
-                    "DisplayName" = "8:"
-                    "Description" = "8:"
-                    "Type" = "3:2"
-                    "ContextData" = "8:InstallToGAC=;IsolateToManifest=_0F5038303B799B1B084A183BC18D01A1.620CD2DC407F43B9916732C473EF22AC"
-                    "Attributes" = "3:0"
-                    "Setting" = "3:2"
-                    "Value" = "8:_0F5038303B799B1B084A183BC18D01A1.620CD2DC407F43B9916732C473EF22AC"
-                    "DefaultValue" = "8:_0F5038303B799B1B084A183BC18D01A1.620CD2DC407F43B9916732C473EF22AC"
-                    "ParentName" = "8:_46E6D2F2ABA84935950C5B6504FA20EF.620CD2DC407F43B9916732C473EF22AC"
-                    "UsePlugInResources" = "11:FALSE"
-                    }
                     "_C1E849892B5F52A712C2C2023D77FFAD.620CD2DC407F43B9916732C473EF22AC"
                     {
                     "Name" = "8:_C1E849892B5F52A712C2C2023D77FFAD.620CD2DC407F43B9916732C473EF22AC"
@@ -3188,20 +2970,6 @@
                     "ParentName" = "8:_46E6D2F2ABA84935950C5B6504FA20EF.620CD2DC407F43B9916732C473EF22AC"
                     "UsePlugInResources" = "11:FALSE"
                     }
-                    "_C599C9EE1106C5BFDFCD5B270271051A.620CD2DC407F43B9916732C473EF22AC"
-                    {
-                    "Name" = "8:_C599C9EE1106C5BFDFCD5B270271051A.620CD2DC407F43B9916732C473EF22AC"
-                    "DisplayName" = "8:"
-                    "Description" = "8:"
-                    "Type" = "3:2"
-                    "ContextData" = "8:InstallToGAC=;IsolateToManifest=_9D9DF977CC7F4E7E87133DD63DEDD201.620CD2DC407F43B9916732C473EF22AC"
-                    "Attributes" = "3:0"
-                    "Setting" = "3:2"
-                    "Value" = "8:_9D9DF977CC7F4E7E87133DD63DEDD201.620CD2DC407F43B9916732C473EF22AC"
-                    "DefaultValue" = "8:_9D9DF977CC7F4E7E87133DD63DEDD201.620CD2DC407F43B9916732C473EF22AC"
-                    "ParentName" = "8:_46E6D2F2ABA84935950C5B6504FA20EF.620CD2DC407F43B9916732C473EF22AC"
-                    "UsePlugInResources" = "11:FALSE"
-                    }
                     "_C8A50762B54B223CDFD91B7D296A4160.620CD2DC407F43B9916732C473EF22AC"
                     {
                     "Name" = "8:_C8A50762B54B223CDFD91B7D296A4160.620CD2DC407F43B9916732C473EF22AC"
@@ -3227,20 +2995,6 @@
                     "Setting" = "3:2"
                     "Value" = "8:_EAAD3A5A3FF546EA891AD9ED920DFD5B.620CD2DC407F43B9916732C473EF22AC"
                     "DefaultValue" = "8:_EAAD3A5A3FF546EA891AD9ED920DFD5B.620CD2DC407F43B9916732C473EF22AC"
-                    "ParentName" = "8:_46E6D2F2ABA84935950C5B6504FA20EF.620CD2DC407F43B9916732C473EF22AC"
-                    "UsePlugInResources" = "11:FALSE"
-                    }
-                    "_CB20D27544078806F99B2FB903CAC296.620CD2DC407F43B9916732C473EF22AC"
-                    {
-                    "Name" = "8:_CB20D27544078806F99B2FB903CAC296.620CD2DC407F43B9916732C473EF22AC"
-                    "DisplayName" = "8:"
-                    "Description" = "8:"
-                    "Type" = "3:2"
-                    "ContextData" = "8:InstallToGAC=;IsolateToManifest=_43EAB630741A42F4AE996108E4118EE6.620CD2DC407F43B9916732C473EF22AC"
-                    "Attributes" = "3:0"
-                    "Setting" = "3:2"
-                    "Value" = "8:_43EAB630741A42F4AE996108E4118EE6.620CD2DC407F43B9916732C473EF22AC"
-                    "DefaultValue" = "8:_43EAB630741A42F4AE996108E4118EE6.620CD2DC407F43B9916732C473EF22AC"
                     "ParentName" = "8:_46E6D2F2ABA84935950C5B6504FA20EF.620CD2DC407F43B9916732C473EF22AC"
                     "UsePlugInResources" = "11:FALSE"
                     }
@@ -3283,20 +3037,6 @@
                     "Setting" = "3:2"
                     "Value" = "8:_F244C9B1D76841B88F95E86743084D97.620CD2DC407F43B9916732C473EF22AC"
                     "DefaultValue" = "8:_F244C9B1D76841B88F95E86743084D97.620CD2DC407F43B9916732C473EF22AC"
-                    "ParentName" = "8:_46E6D2F2ABA84935950C5B6504FA20EF.620CD2DC407F43B9916732C473EF22AC"
-                    "UsePlugInResources" = "11:FALSE"
-                    }
-                    "_CE5BE3BA884E0263BEDA0A678C302825.620CD2DC407F43B9916732C473EF22AC"
-                    {
-                    "Name" = "8:_CE5BE3BA884E0263BEDA0A678C302825.620CD2DC407F43B9916732C473EF22AC"
-                    "DisplayName" = "8:"
-                    "Description" = "8:"
-                    "Type" = "3:2"
-                    "ContextData" = "8:InstallToGAC=;IsolateToManifest=_C4321F1C39E149AE90CD1FD0B85D1C11.620CD2DC407F43B9916732C473EF22AC"
-                    "Attributes" = "3:0"
-                    "Setting" = "3:2"
-                    "Value" = "8:_C4321F1C39E149AE90CD1FD0B85D1C11.620CD2DC407F43B9916732C473EF22AC"
-                    "DefaultValue" = "8:_C4321F1C39E149AE90CD1FD0B85D1C11.620CD2DC407F43B9916732C473EF22AC"
                     "ParentName" = "8:_46E6D2F2ABA84935950C5B6504FA20EF.620CD2DC407F43B9916732C473EF22AC"
                     "UsePlugInResources" = "11:FALSE"
                     }
@@ -3381,6 +3121,20 @@
                     "Setting" = "3:2"
                     "Value" = "8:_CD6BB4F96321436B8AE9005A69987174.620CD2DC407F43B9916732C473EF22AC"
                     "DefaultValue" = "8:_CD6BB4F96321436B8AE9005A69987174.620CD2DC407F43B9916732C473EF22AC"
+                    "ParentName" = "8:_46E6D2F2ABA84935950C5B6504FA20EF.620CD2DC407F43B9916732C473EF22AC"
+                    "UsePlugInResources" = "11:FALSE"
+                    }
+                    "_D65F83D2FFF24CED1D1ADCB028443EC4.620CD2DC407F43B9916732C473EF22AC"
+                    {
+                    "Name" = "8:_D65F83D2FFF24CED1D1ADCB028443EC4.620CD2DC407F43B9916732C473EF22AC"
+                    "DisplayName" = "8:"
+                    "Description" = "8:"
+                    "Type" = "3:2"
+                    "ContextData" = "8:InstallToGAC=;IsolateToManifest=_18ADB409D6CF4360B2BBBD51B3985685.620CD2DC407F43B9916732C473EF22AC"
+                    "Attributes" = "3:0"
+                    "Setting" = "3:2"
+                    "Value" = "8:_18ADB409D6CF4360B2BBBD51B3985685.620CD2DC407F43B9916732C473EF22AC"
+                    "DefaultValue" = "8:_18ADB409D6CF4360B2BBBD51B3985685.620CD2DC407F43B9916732C473EF22AC"
                     "ParentName" = "8:_46E6D2F2ABA84935950C5B6504FA20EF.620CD2DC407F43B9916732C473EF22AC"
                     "UsePlugInResources" = "11:FALSE"
                     }
@@ -3608,20 +3362,6 @@
                     "ParentName" = "8:_46E6D2F2ABA84935950C5B6504FA20EF.620CD2DC407F43B9916732C473EF22AC"
                     "UsePlugInResources" = "11:FALSE"
                     }
-                    "_ED4497470E1C03F9FF9C4B5B15F99DA6.620CD2DC407F43B9916732C473EF22AC"
-                    {
-                    "Name" = "8:_ED4497470E1C03F9FF9C4B5B15F99DA6.620CD2DC407F43B9916732C473EF22AC"
-                    "DisplayName" = "8:"
-                    "Description" = "8:"
-                    "Type" = "3:2"
-                    "ContextData" = "8:InstallToGAC=;IsolateToManifest=_7E138086B58E4D6D99F88219BCCC82A3.620CD2DC407F43B9916732C473EF22AC"
-                    "Attributes" = "3:0"
-                    "Setting" = "3:2"
-                    "Value" = "8:_7E138086B58E4D6D99F88219BCCC82A3.620CD2DC407F43B9916732C473EF22AC"
-                    "DefaultValue" = "8:_7E138086B58E4D6D99F88219BCCC82A3.620CD2DC407F43B9916732C473EF22AC"
-                    "ParentName" = "8:_46E6D2F2ABA84935950C5B6504FA20EF.620CD2DC407F43B9916732C473EF22AC"
-                    "UsePlugInResources" = "11:FALSE"
-                    }
                     "_EEBFB812EC35BAF3B80D13C5F04E5E62.620CD2DC407F43B9916732C473EF22AC"
                     {
                     "Name" = "8:_EEBFB812EC35BAF3B80D13C5F04E5E62.620CD2DC407F43B9916732C473EF22AC"
@@ -3689,34 +3429,6 @@
                     "Setting" = "3:2"
                     "Value" = "8:_582F74560F10433988C13109226E8B60.620CD2DC407F43B9916732C473EF22AC"
                     "DefaultValue" = "8:_582F74560F10433988C13109226E8B60.620CD2DC407F43B9916732C473EF22AC"
-                    "ParentName" = "8:_46E6D2F2ABA84935950C5B6504FA20EF.620CD2DC407F43B9916732C473EF22AC"
-                    "UsePlugInResources" = "11:FALSE"
-                    }
-                    "_F9D291C18D0CF137B1AA64C5BBAE2800.620CD2DC407F43B9916732C473EF22AC"
-                    {
-                    "Name" = "8:_F9D291C18D0CF137B1AA64C5BBAE2800.620CD2DC407F43B9916732C473EF22AC"
-                    "DisplayName" = "8:"
-                    "Description" = "8:"
-                    "Type" = "3:2"
-                    "ContextData" = "8:InstallToGAC=;IsolateToManifest=_CED0297D625A4360AA42767C75EE7C18.620CD2DC407F43B9916732C473EF22AC"
-                    "Attributes" = "3:0"
-                    "Setting" = "3:2"
-                    "Value" = "8:_CED0297D625A4360AA42767C75EE7C18.620CD2DC407F43B9916732C473EF22AC"
-                    "DefaultValue" = "8:_CED0297D625A4360AA42767C75EE7C18.620CD2DC407F43B9916732C473EF22AC"
-                    "ParentName" = "8:_46E6D2F2ABA84935950C5B6504FA20EF.620CD2DC407F43B9916732C473EF22AC"
-                    "UsePlugInResources" = "11:FALSE"
-                    }
-                    "_FDD7ACB2F34584A54A2E87EF3FF19509.620CD2DC407F43B9916732C473EF22AC"
-                    {
-                    "Name" = "8:_FDD7ACB2F34584A54A2E87EF3FF19509.620CD2DC407F43B9916732C473EF22AC"
-                    "DisplayName" = "8:"
-                    "Description" = "8:"
-                    "Type" = "3:2"
-                    "ContextData" = "8:InstallToGAC=;IsolateToManifest=_E4D5B57730EF440E8D7A963FF5EA7E25.620CD2DC407F43B9916732C473EF22AC"
-                    "Attributes" = "3:0"
-                    "Setting" = "3:2"
-                    "Value" = "8:_E4D5B57730EF440E8D7A963FF5EA7E25.620CD2DC407F43B9916732C473EF22AC"
-                    "DefaultValue" = "8:_E4D5B57730EF440E8D7A963FF5EA7E25.620CD2DC407F43B9916732C473EF22AC"
                     "ParentName" = "8:_46E6D2F2ABA84935950C5B6504FA20EF.620CD2DC407F43B9916732C473EF22AC"
                     "UsePlugInResources" = "11:FALSE"
                     }

--- a/Installers/SetupPayload64/SetupPayload64.vdproj
+++ b/Installers/SetupPayload64/SetupPayload64.vdproj
@@ -87,12 +87,6 @@
         }
         "Entry"
         {
-        "MsmKey" = "8:_13D448C2139643F5A6918B01FA8CB5DF"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
         "MsmKey" = "8:_13E50A08E42B4C6FBCB3B94AC843E390"
         "OwnerKey" = "8:_UNDEFINED"
         "MsmSig" = "8:_UNDEFINED"
@@ -112,12 +106,6 @@
         "Entry"
         {
         "MsmKey" = "8:_1693C46D3D9C4FFE9C1FFF9C94915474"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_190CF557D39E4FD5A741CA40C94A7DC5"
         "OwnerKey" = "8:_UNDEFINED"
         "MsmSig" = "8:_UNDEFINED"
         }
@@ -147,12 +135,6 @@
         }
         "Entry"
         {
-        "MsmKey" = "8:_1B862C84828D4704B974EF54CDC6F2F0"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
         "MsmKey" = "8:_1D2EAD169AF14283BF54CB4E555570E1"
         "OwnerKey" = "8:_UNDEFINED"
         "MsmSig" = "8:_UNDEFINED"
@@ -166,12 +148,6 @@
         "Entry"
         {
         "MsmKey" = "8:_20B4493781CB488B9C80246C7550054A"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_210F8294099844DCBA0719148283D6E8"
         "OwnerKey" = "8:_UNDEFINED"
         "MsmSig" = "8:_UNDEFINED"
         }
@@ -237,12 +213,6 @@
         }
         "Entry"
         {
-        "MsmKey" = "8:_2BAC679FA2284860971D6C050FA4E76A"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
         "MsmKey" = "8:_2BAC7308D6EF4B31904B41D864B04896"
         "OwnerKey" = "8:_UNDEFINED"
         "MsmSig" = "8:_UNDEFINED"
@@ -297,12 +267,6 @@
         }
         "Entry"
         {
-        "MsmKey" = "8:_36716D06930941819F6E1EF2088B7861"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
         "MsmKey" = "8:_37D33886C7AD4143A6D40ACDB689FC17"
         "OwnerKey" = "8:_UNDEFINED"
         "MsmSig" = "8:_UNDEFINED"
@@ -328,18 +292,6 @@
         "Entry"
         {
         "MsmKey" = "8:_3E9672043AA54AAFBD594B3F939D6156"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_40384720FEE043ECA975BD43593A3F50"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_408793932C71490182C1AA0A07D08EA0"
         "OwnerKey" = "8:_UNDEFINED"
         "MsmSig" = "8:_UNDEFINED"
         }
@@ -411,12 +363,6 @@
         }
         "Entry"
         {
-        "MsmKey" = "8:_4C1DEC9B3B0A45599A31D801EB69E151"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
         "MsmKey" = "8:_4D818C8EE4724E9CB1D210A573D168D4"
         "OwnerKey" = "8:_UNDEFINED"
         "MsmSig" = "8:_UNDEFINED"
@@ -424,12 +370,6 @@
         "Entry"
         {
         "MsmKey" = "8:_4F1C48D1BA9E4429A06F3EFC8042FFF7"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_4FB2C7F2E91A45D7A13DDDCCD335FEDB"
         "OwnerKey" = "8:_UNDEFINED"
         "MsmSig" = "8:_UNDEFINED"
         }
@@ -460,12 +400,6 @@
         "Entry"
         {
         "MsmKey" = "8:_55FA81E6B2404248BD6EED2D19DF4938"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_57636C844DC7404787926E8B88D6C05A"
         "OwnerKey" = "8:_UNDEFINED"
         "MsmSig" = "8:_UNDEFINED"
         }
@@ -519,25 +453,7 @@
         }
         "Entry"
         {
-        "MsmKey" = "8:_642141C11D594B71BEF485398FF1066A"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
         "MsmKey" = "8:_656199758E544D4988AC1BEF94CF8CC9"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_67DF35398F074D428CB47E5DAD55D329"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_67E8E0F1B4194C90B8512C7015C7F02E"
         "OwnerKey" = "8:_UNDEFINED"
         "MsmSig" = "8:_UNDEFINED"
         }
@@ -783,18 +699,6 @@
         }
         "Entry"
         {
-        "MsmKey" = "8:_951B9380582DF1E7083BB146B5B972DE"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_9793BDDD63FF4018AAD8423D946EF390"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
         "MsmKey" = "8:_9793BDDD63FF4018AAD8423D946EF390"
         "OwnerKey" = "8:_UNDEFINED"
         "MsmSig" = "8:_UNDEFINED"
@@ -815,6 +719,12 @@
         {
         "MsmKey" = "8:_9AD3FC28446146C2916A27087D967800"
         "OwnerKey" = "8:_UNDEFINED"
+        "MsmSig" = "8:_UNDEFINED"
+        }
+        "Entry"
+        {
+        "MsmKey" = "8:_9AE1F5C21871D3B29046ABB74D006906"
+        "OwnerKey" = "8:_116456FA461249C891C2F971CC5D4BD0"
         "MsmSig" = "8:_UNDEFINED"
         }
         "Entry"
@@ -903,12 +813,6 @@
         }
         "Entry"
         {
-        "MsmKey" = "8:_AADD36F6B97F403495AEC87429288C87"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
         "MsmKey" = "8:_ACBB7A53E4154411A8736DB66962315C"
         "OwnerKey" = "8:_UNDEFINED"
         "MsmSig" = "8:_UNDEFINED"
@@ -916,12 +820,6 @@
         "Entry"
         {
         "MsmKey" = "8:_B041E1DF6BFB4FEDAEB6500A53D13B80"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_B145E5EB173145D699545451BD2BAD93"
         "OwnerKey" = "8:_UNDEFINED"
         "MsmSig" = "8:_UNDEFINED"
         }
@@ -1017,18 +915,6 @@
         }
         "Entry"
         {
-        "MsmKey" = "8:_C258DCC2A97441CC8D4CE99B30CCFE30"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_C2B6ECF719F84B17BE42A75B4AFC85FC"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
         "MsmKey" = "8:_C30DC62295394EAD816A84875FBC2873"
         "OwnerKey" = "8:_UNDEFINED"
         "MsmSig" = "8:_UNDEFINED"
@@ -1036,12 +922,6 @@
         "Entry"
         {
         "MsmKey" = "8:_C62E48F788494642B370A278E8CCEBC6"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_C74366375A7448EABFE460BBBC5E142A"
         "OwnerKey" = "8:_UNDEFINED"
         "MsmSig" = "8:_UNDEFINED"
         }
@@ -1089,19 +969,7 @@
         }
         "Entry"
         {
-        "MsmKey" = "8:_CFA5745E6EEB4CD7A5170E2B8AA28D94"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
         "MsmKey" = "8:_D1ADCB0D1B8243218A9C4E45BC47DB74"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_D31E1D294B5D4340BD3E59D1E766383D"
         "OwnerKey" = "8:_UNDEFINED"
         "MsmSig" = "8:_UNDEFINED"
         }
@@ -1126,12 +994,6 @@
         "Entry"
         {
         "MsmKey" = "8:_D6FA39374843425EAC70A0ADB346FD06"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_D8510077E8014D0B95EABA90EA8C06A0"
         "OwnerKey" = "8:_UNDEFINED"
         "MsmSig" = "8:_UNDEFINED"
         }
@@ -1179,19 +1041,7 @@
         }
         "Entry"
         {
-        "MsmKey" = "8:_E2C042031A57431A9205FC9FCB561C49"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
         "MsmKey" = "8:_E71196F15A0F41C5B8CDB9293AE2E85A"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_E71C20ACF4664261A7ECB8759C724614"
         "OwnerKey" = "8:_UNDEFINED"
         "MsmSig" = "8:_UNDEFINED"
         }
@@ -1287,12 +1137,6 @@
         }
         "Entry"
         {
-        "MsmKey" = "8:_F319F875992947DB96A70712D6CF39D4"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
         "MsmKey" = "8:_F40309BB4D594A64BC6D4A5C74C7DA3A"
         "OwnerKey" = "8:_UNDEFINED"
         "MsmSig" = "8:_UNDEFINED"
@@ -1300,12 +1144,6 @@
         "Entry"
         {
         "MsmKey" = "8:_F42C988C532244AC947507F44012942F"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_F4B1CF931C44450FB1E4876D3041921F"
         "OwnerKey" = "8:_UNDEFINED"
         "MsmSig" = "8:_UNDEFINED"
         }
@@ -1347,25 +1185,7 @@
         }
         "Entry"
         {
-        "MsmKey" = "8:_FAEC8D5E7D7946D6B028D47DDEDA4E96"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_FC8986371CB34FDE85D9F41E61CF301E"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
         "MsmKey" = "8:_FD1AD3B6A959440DB8D217548E05ED75"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_FDA28938341845008A82CE6C5CC78608"
         "OwnerKey" = "8:_UNDEFINED"
         "MsmSig" = "8:_UNDEFINED"
         }
@@ -1384,7 +1204,7 @@
         "Entry"
         {
         "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_FDA28938341845008A82CE6C5CC78608"
+        "OwnerKey" = "8:_81F745121006405BA208BB4B80254F8A"
         "MsmSig" = "8:_UNDEFINED"
         }
         "Entry"
@@ -1397,30 +1217,6 @@
         {
         "MsmKey" = "8:_UNDEFINED"
         "OwnerKey" = "8:_FD1AD3B6A959440DB8D217548E05ED75"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_FC8986371CB34FDE85D9F41E61CF301E"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_FAEC8D5E7D7946D6B028D47DDEDA4E96"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_F4B1CF931C44450FB1E4876D3041921F"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_F319F875992947DB96A70712D6CF39D4"
         "MsmSig" = "8:_UNDEFINED"
         }
         "Entry"
@@ -1444,18 +1240,6 @@
         "Entry"
         {
         "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_E71C20ACF4664261A7ECB8759C724614"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_E2C042031A57431A9205FC9FCB561C49"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_UNDEFINED"
         "OwnerKey" = "8:_DAC9D6CC39624A82A021B046F82F8F81"
         "MsmSig" = "8:_UNDEFINED"
         }
@@ -1468,25 +1252,7 @@
         "Entry"
         {
         "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_D8510077E8014D0B95EABA90EA8C06A0"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_UNDEFINED"
         "OwnerKey" = "8:_D4981DDE206D4274A86E2C7B2BB28886"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_D31E1D294B5D4340BD3E59D1E766383D"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_CFA5745E6EEB4CD7A5170E2B8AA28D94"
         "MsmSig" = "8:_UNDEFINED"
         }
         "Entry"
@@ -1510,25 +1276,7 @@
         "Entry"
         {
         "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_C74366375A7448EABFE460BBBC5E142A"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_UNDEFINED"
         "OwnerKey" = "8:_C62E48F788494642B370A278E8CCEBC6"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_C2B6ECF719F84B17BE42A75B4AFC85FC"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_C258DCC2A97441CC8D4CE99B30CCFE30"
         "MsmSig" = "8:_UNDEFINED"
         }
         "Entry"
@@ -1565,18 +1313,6 @@
         {
         "MsmKey" = "8:_UNDEFINED"
         "OwnerKey" = "8:_B2B29EF66E2E48BBA25F63503604BFDA"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_B145E5EB173145D699545451BD2BAD93"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_AADD36F6B97F403495AEC87429288C87"
         "MsmSig" = "8:_UNDEFINED"
         }
         "Entry"
@@ -1660,31 +1396,7 @@
         "Entry"
         {
         "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_67E8E0F1B4194C90B8512C7015C7F02E"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_67DF35398F074D428CB47E5DAD55D329"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_642141C11D594B71BEF485398FF1066A"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_UNDEFINED"
         "OwnerKey" = "8:_603ACD53734241D5ACC02B6048B91CE2"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_57636C844DC7404787926E8B88D6C05A"
         "MsmSig" = "8:_UNDEFINED"
         }
         "Entry"
@@ -1708,19 +1420,7 @@
         "Entry"
         {
         "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_4FB2C7F2E91A45D7A13DDDCCD335FEDB"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_UNDEFINED"
         "OwnerKey" = "8:_4F1C48D1BA9E4429A06F3EFC8042FFF7"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_4C1DEC9B3B0A45599A31D801EB69E151"
         "MsmSig" = "8:_UNDEFINED"
         }
         "Entry"
@@ -1750,25 +1450,7 @@
         "Entry"
         {
         "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_408793932C71490182C1AA0A07D08EA0"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_40384720FEE043ECA975BD43593A3F50"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_UNDEFINED"
         "OwnerKey" = "8:_37FF64E9BD3E46CF98CE35FE67095FC2"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_36716D06930941819F6E1EF2088B7861"
         "MsmSig" = "8:_UNDEFINED"
         }
         "Entry"
@@ -1780,31 +1462,19 @@
         "Entry"
         {
         "MsmKey" = "8:_UNDEFINED"
+        "OwnerKey" = "8:_2E378C60DB144793BE361E98417441BE"
+        "MsmSig" = "8:_UNDEFINED"
+        }
+        "Entry"
+        {
+        "MsmKey" = "8:_UNDEFINED"
         "OwnerKey" = "8:_2D5946782776470DAE7A7B8F611D2C46"
         "MsmSig" = "8:_UNDEFINED"
         }
         "Entry"
         {
         "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_2BAC679FA2284860971D6C050FA4E76A"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_UNDEFINED"
         "OwnerKey" = "8:_2AFB0E028E114E368607D645A082FD77"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_210F8294099844DCBA0719148283D6E8"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_1B862C84828D4704B974EF54CDC6F2F0"
         "MsmSig" = "8:_UNDEFINED"
         }
         "Entry"
@@ -1817,18 +1487,6 @@
         {
         "MsmKey" = "8:_UNDEFINED"
         "OwnerKey" = "8:_1B2F74B944FE4B49B559D206D3722AAA"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_190CF557D39E4FD5A741CA40C94A7DC5"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_13D448C2139643F5A6918B01FA8CB5DF"
         "MsmSig" = "8:_UNDEFINED"
         }
         "Entry"
@@ -1853,24 +1511,6 @@
         {
         "MsmKey" = "8:_UNDEFINED"
         "OwnerKey" = "8:_81F745121006405BA208BB4B80254F8A"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_951B9380582DF1E7083BB146B5B972DE"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_81F745121006405BA208BB4B80254F8A"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_2E378C60DB144793BE361E98417441BE"
         "MsmSig" = "8:_UNDEFINED"
         }
     }
@@ -2315,37 +1955,6 @@
             "IsDependency" = "11:FALSE"
             "IsolateTo" = "8:"
             }
-            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_13D448C2139643F5A6918B01FA8CB5DF"
-            {
-            "AssemblyRegister" = "3:1"
-            "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:IKVM.OpenJDK.XML.Parse, Version=8.1.5717.0, Culture=neutral, PublicKeyToken=13235d27fcbfff58, processorArchitecture=MSIL"
-                "ScatterAssemblies"
-                {
-                    "_13D448C2139643F5A6918B01FA8CB5DF"
-                    {
-                    "Name" = "8:IKVM.OpenJDK.XML.Parse.dll"
-                    "Attributes" = "3:512"
-                    }
-                }
-            "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x64\\IKVM.OpenJDK.XML.Parse.dll"
-            "TargetName" = "8:"
-            "Tag" = "8:"
-            "Folder" = "8:_BE7C8A748AB042DFB3B17E4D4E332955"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
             "{1FB2D0AE-D3B9-43D4-B9DD-F88EC61E35DE}:_13E50A08E42B4C6FBCB3B94AC843E390"
             {
             "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x64\\MahApps.Metro.IconPacks.pdb"
@@ -2432,37 +2041,6 @@
             {
             "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x64\\libuv.dll"
             "TargetName" = "8:libuv.dll"
-            "Tag" = "8:"
-            "Folder" = "8:_BE7C8A748AB042DFB3B17E4D4E332955"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
-            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_190CF557D39E4FD5A741CA40C94A7DC5"
-            {
-            "AssemblyRegister" = "3:1"
-            "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:IKVM.OpenJDK.Charsets, Version=8.1.5717.0, Culture=neutral, PublicKeyToken=13235d27fcbfff58, processorArchitecture=MSIL"
-                "ScatterAssemblies"
-                {
-                    "_190CF557D39E4FD5A741CA40C94A7DC5"
-                    {
-                    "Name" = "8:IKVM.OpenJDK.Charsets.dll"
-                    "Attributes" = "3:512"
-                    }
-                }
-            "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x64\\IKVM.OpenJDK.Charsets.dll"
-            "TargetName" = "8:"
             "Tag" = "8:"
             "Folder" = "8:_BE7C8A748AB042DFB3B17E4D4E332955"
             "Condition" = "8:"
@@ -2603,37 +2181,6 @@
             "IsDependency" = "11:FALSE"
             "IsolateTo" = "8:"
             }
-            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_1B862C84828D4704B974EF54CDC6F2F0"
-            {
-            "AssemblyRegister" = "3:1"
-            "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:IKVM.Runtime.JNI, Version=8.1.5717.0, Culture=neutral, PublicKeyToken=13235d27fcbfff58, processorArchitecture=MSIL"
-                "ScatterAssemblies"
-                {
-                    "_1B862C84828D4704B974EF54CDC6F2F0"
-                    {
-                    "Name" = "8:IKVM.Runtime.JNI.dll"
-                    "Attributes" = "3:512"
-                    }
-                }
-            "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x64\\IKVM.Runtime.JNI.dll"
-            "TargetName" = "8:"
-            "Tag" = "8:"
-            "Folder" = "8:_BE7C8A748AB042DFB3B17E4D4E332955"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
             "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_1D2EAD169AF14283BF54CB4E555570E1"
             {
             "AssemblyRegister" = "3:1"
@@ -2699,37 +2246,6 @@
                     }
                 }
             "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x64\\System.IO.Pipes.dll"
-            "TargetName" = "8:"
-            "Tag" = "8:"
-            "Folder" = "8:_BE7C8A748AB042DFB3B17E4D4E332955"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
-            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_210F8294099844DCBA0719148283D6E8"
-            {
-            "AssemblyRegister" = "3:1"
-            "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:IKVM.OpenJDK.Jdbc, Version=8.1.5717.0, Culture=neutral, PublicKeyToken=13235d27fcbfff58, processorArchitecture=MSIL"
-                "ScatterAssemblies"
-                {
-                    "_210F8294099844DCBA0719148283D6E8"
-                    {
-                    "Name" = "8:IKVM.OpenJDK.Jdbc.dll"
-                    "Attributes" = "3:512"
-                    }
-                }
-            "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x64\\IKVM.OpenJDK.Jdbc.dll"
             "TargetName" = "8:"
             "Tag" = "8:"
             "Folder" = "8:_BE7C8A748AB042DFB3B17E4D4E332955"
@@ -2997,37 +2513,6 @@
             {
             "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x64\\Microsoft.Practices.ServiceLocation.pdb"
             "TargetName" = "8:Microsoft.Practices.ServiceLocation.pdb"
-            "Tag" = "8:"
-            "Folder" = "8:_BE7C8A748AB042DFB3B17E4D4E332955"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
-            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_2BAC679FA2284860971D6C050FA4E76A"
-            {
-            "AssemblyRegister" = "3:1"
-            "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:IKVM.OpenJDK.Nashorn, Version=8.1.5717.0, Culture=neutral, PublicKeyToken=13235d27fcbfff58, processorArchitecture=MSIL"
-                "ScatterAssemblies"
-                {
-                    "_2BAC679FA2284860971D6C050FA4E76A"
-                    {
-                    "Name" = "8:IKVM.OpenJDK.Nashorn.dll"
-                    "Attributes" = "3:512"
-                    }
-                }
-            "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x64\\IKVM.OpenJDK.Nashorn.dll"
-            "TargetName" = "8:"
             "Tag" = "8:"
             "Folder" = "8:_BE7C8A748AB042DFB3B17E4D4E332955"
             "Condition" = "8:"
@@ -3323,37 +2808,6 @@
             "IsDependency" = "11:FALSE"
             "IsolateTo" = "8:"
             }
-            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_36716D06930941819F6E1EF2088B7861"
-            {
-            "AssemblyRegister" = "3:1"
-            "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:IKVM.OpenJDK.Remoting, Version=8.1.5717.0, Culture=neutral, PublicKeyToken=13235d27fcbfff58, processorArchitecture=MSIL"
-                "ScatterAssemblies"
-                {
-                    "_36716D06930941819F6E1EF2088B7861"
-                    {
-                    "Name" = "8:IKVM.OpenJDK.Remoting.dll"
-                    "Attributes" = "3:512"
-                    }
-                }
-            "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x64\\IKVM.OpenJDK.Remoting.dll"
-            "TargetName" = "8:"
-            "Tag" = "8:"
-            "Folder" = "8:_BE7C8A748AB042DFB3B17E4D4E332955"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
             "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_37D33886C7AD4143A6D40ACDB689FC17"
             {
             "AssemblyRegister" = "3:1"
@@ -3509,68 +2963,6 @@
             "IsDependency" = "11:FALSE"
             "IsolateTo" = "8:"
             }
-            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_40384720FEE043ECA975BD43593A3F50"
-            {
-            "AssemblyRegister" = "3:1"
-            "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:IKVM.OpenJDK.Security, Version=8.1.5717.0, Culture=neutral, PublicKeyToken=13235d27fcbfff58, processorArchitecture=MSIL"
-                "ScatterAssemblies"
-                {
-                    "_40384720FEE043ECA975BD43593A3F50"
-                    {
-                    "Name" = "8:IKVM.OpenJDK.Security.dll"
-                    "Attributes" = "3:512"
-                    }
-                }
-            "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x64\\IKVM.OpenJDK.Security.dll"
-            "TargetName" = "8:"
-            "Tag" = "8:"
-            "Folder" = "8:_BE7C8A748AB042DFB3B17E4D4E332955"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
-            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_408793932C71490182C1AA0A07D08EA0"
-            {
-            "AssemblyRegister" = "3:1"
-            "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:IKVM.OpenJDK.Management, Version=8.1.5717.0, Culture=neutral, PublicKeyToken=13235d27fcbfff58, processorArchitecture=MSIL"
-                "ScatterAssemblies"
-                {
-                    "_408793932C71490182C1AA0A07D08EA0"
-                    {
-                    "Name" = "8:IKVM.OpenJDK.Management.dll"
-                    "Attributes" = "3:512"
-                    }
-                }
-            "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x64\\IKVM.OpenJDK.Management.dll"
-            "TargetName" = "8:"
-            "Tag" = "8:"
-            "Folder" = "8:_BE7C8A748AB042DFB3B17E4D4E332955"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
             "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_40CBB7A343154AB98F8C68A586DEF2AB"
             {
             "AssemblyRegister" = "3:1"
@@ -3668,7 +3060,7 @@
             {
             "AssemblyRegister" = "3:1"
             "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:FilterServiceProvider, Version=1.6.13.0, Culture=neutral, processorArchitecture=AMD64"
+            "AssemblyAsmDisplayName" = "8:FilterServiceProvider, Version=1.6.17.0, Culture=neutral, processorArchitecture=AMD64"
                 "ScatterAssemblies"
                 {
                     "_4595D371A3474725B6AF74ABF2F3A814"
@@ -3912,37 +3304,6 @@
             "IsDependency" = "11:FALSE"
             "IsolateTo" = "8:"
             }
-            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_4C1DEC9B3B0A45599A31D801EB69E151"
-            {
-            "AssemblyRegister" = "3:1"
-            "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:IKVM.OpenJDK.Core, Version=8.1.5717.0, Culture=neutral, PublicKeyToken=13235d27fcbfff58, processorArchitecture=MSIL"
-                "ScatterAssemblies"
-                {
-                    "_4C1DEC9B3B0A45599A31D801EB69E151"
-                    {
-                    "Name" = "8:IKVM.OpenJDK.Core.dll"
-                    "Attributes" = "3:512"
-                    }
-                }
-            "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x64\\IKVM.OpenJDK.Core.dll"
-            "TargetName" = "8:"
-            "Tag" = "8:"
-            "Folder" = "8:_BE7C8A748AB042DFB3B17E4D4E332955"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
             "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_4D818C8EE4724E9CB1D210A573D168D4"
             {
             "AssemblyRegister" = "3:1"
@@ -3978,7 +3339,7 @@
             {
             "AssemblyRegister" = "3:1"
             "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:Citadel.IPC.Common, Version=1.6.15.0, Culture=neutral, processorArchitecture=MSIL"
+            "AssemblyAsmDisplayName" = "8:Citadel.IPC.Common, Version=1.6.17.0, Culture=neutral, processorArchitecture=MSIL"
                 "ScatterAssemblies"
                 {
                     "_4F1C48D1BA9E4429A06F3EFC8042FFF7"
@@ -3988,37 +3349,6 @@
                     }
                 }
             "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x64\\Citadel.IPC.Common.dll"
-            "TargetName" = "8:"
-            "Tag" = "8:"
-            "Folder" = "8:_BE7C8A748AB042DFB3B17E4D4E332955"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
-            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_4FB2C7F2E91A45D7A13DDDCCD335FEDB"
-            {
-            "AssemblyRegister" = "3:1"
-            "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:IKVM.OpenJDK.XML.Transform, Version=8.1.5717.0, Culture=neutral, PublicKeyToken=13235d27fcbfff58, processorArchitecture=MSIL"
-                "ScatterAssemblies"
-                {
-                    "_4FB2C7F2E91A45D7A13DDDCCD335FEDB"
-                    {
-                    "Name" = "8:IKVM.OpenJDK.XML.Transform.dll"
-                    "Attributes" = "3:512"
-                    }
-                }
-            "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x64\\IKVM.OpenJDK.XML.Transform.dll"
             "TargetName" = "8:"
             "Tag" = "8:"
             "Folder" = "8:_BE7C8A748AB042DFB3B17E4D4E332955"
@@ -4174,37 +3504,6 @@
                     }
                 }
             "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x64\\System.Reflection.Metadata.dll"
-            "TargetName" = "8:"
-            "Tag" = "8:"
-            "Folder" = "8:_BE7C8A748AB042DFB3B17E4D4E332955"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
-            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_57636C844DC7404787926E8B88D6C05A"
-            {
-            "AssemblyRegister" = "3:1"
-            "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:IKVM.OpenJDK.XML.API, Version=8.1.5717.0, Culture=neutral, PublicKeyToken=13235d27fcbfff58, processorArchitecture=MSIL"
-                "ScatterAssemblies"
-                {
-                    "_57636C844DC7404787926E8B88D6C05A"
-                    {
-                    "Name" = "8:IKVM.OpenJDK.XML.API.dll"
-                    "Attributes" = "3:512"
-                    }
-                }
-            "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x64\\IKVM.OpenJDK.XML.API.dll"
             "TargetName" = "8:"
             "Tag" = "8:"
             "Folder" = "8:_BE7C8A748AB042DFB3B17E4D4E332955"
@@ -4470,37 +3769,6 @@
             "IsDependency" = "11:FALSE"
             "IsolateTo" = "8:"
             }
-            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_642141C11D594B71BEF485398FF1066A"
-            {
-            "AssemblyRegister" = "3:1"
-            "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:IKVM.OpenJDK.Media, Version=8.1.5717.0, Culture=neutral, PublicKeyToken=13235d27fcbfff58, processorArchitecture=MSIL"
-                "ScatterAssemblies"
-                {
-                    "_642141C11D594B71BEF485398FF1066A"
-                    {
-                    "Name" = "8:IKVM.OpenJDK.Media.dll"
-                    "Attributes" = "3:512"
-                    }
-                }
-            "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x64\\IKVM.OpenJDK.Media.dll"
-            "TargetName" = "8:"
-            "Tag" = "8:"
-            "Folder" = "8:_BE7C8A748AB042DFB3B17E4D4E332955"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
             "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_656199758E544D4988AC1BEF94CF8CC9"
             {
             "AssemblyRegister" = "3:1"
@@ -4515,68 +3783,6 @@
                     }
                 }
             "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x64\\System.Runtime.dll"
-            "TargetName" = "8:"
-            "Tag" = "8:"
-            "Folder" = "8:_BE7C8A748AB042DFB3B17E4D4E332955"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
-            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_67DF35398F074D428CB47E5DAD55D329"
-            {
-            "AssemblyRegister" = "3:1"
-            "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:IKVM.OpenJDK.SwingAWT, Version=8.1.5717.0, Culture=neutral, PublicKeyToken=13235d27fcbfff58, processorArchitecture=MSIL"
-                "ScatterAssemblies"
-                {
-                    "_67DF35398F074D428CB47E5DAD55D329"
-                    {
-                    "Name" = "8:IKVM.OpenJDK.SwingAWT.dll"
-                    "Attributes" = "3:512"
-                    }
-                }
-            "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x64\\IKVM.OpenJDK.SwingAWT.dll"
-            "TargetName" = "8:"
-            "Tag" = "8:"
-            "Folder" = "8:_BE7C8A748AB042DFB3B17E4D4E332955"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
-            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_67E8E0F1B4194C90B8512C7015C7F02E"
-            {
-            "AssemblyRegister" = "3:1"
-            "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:OpenNLP.IKVM, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL"
-                "ScatterAssemblies"
-                {
-                    "_67E8E0F1B4194C90B8512C7015C7F02E"
-                    {
-                    "Name" = "8:OpenNLP.IKVM.dll"
-                    "Attributes" = "3:512"
-                    }
-                }
-            "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x64\\OpenNLP.IKVM.dll"
             "TargetName" = "8:"
             "Tag" = "8:"
             "Folder" = "8:_BE7C8A748AB042DFB3B17E4D4E332955"
@@ -4948,7 +4154,7 @@
             {
             "AssemblyRegister" = "3:1"
             "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:CitadelCore.Windows, Version=1.3.3.0, Culture=neutral, processorArchitecture=MSIL"
+            "AssemblyAsmDisplayName" = "8:CitadelCore.Windows, Version=1.3.4.0, Culture=neutral, processorArchitecture=MSIL"
                 "ScatterAssemblies"
                 {
                     "_73E88F3BC18946628C11912BD94AF041"
@@ -5759,37 +4965,6 @@
             "IsDependency" = "11:FALSE"
             "IsolateTo" = "8:"
             }
-            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_951B9380582DF1E7083BB146B5B972DE"
-            {
-            "AssemblyRegister" = "3:1"
-            "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:System.Net.Http, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"
-                "ScatterAssemblies"
-                {
-                    "_951B9380582DF1E7083BB146B5B972DE"
-                    {
-                    "Name" = "8:System.Net.Http.dll"
-                    "Attributes" = "3:512"
-                    }
-                }
-            "SourcePath" = "8:System.Net.Http.dll"
-            "TargetName" = "8:"
-            "Tag" = "8:"
-            "Folder" = "8:_BE7C8A748AB042DFB3B17E4D4E332955"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:TRUE"
-            "IsolateTo" = "8:"
-            }
             "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_9793BDDD63FF4018AAD8423D946EF390"
             {
             "AssemblyRegister" = "3:1"
@@ -5919,7 +5094,7 @@
             "SourcePath" = "8:FirewallAPI.dll"
             "TargetName" = "8:FirewallAPI.dll"
             "Tag" = "8:"
-            "Folder" = "8:_57C3A9BBDB2B47F79455955116C98E2D"
+            "Folder" = "8:_BE7C8A748AB042DFB3B17E4D4E332955"
             "Condition" = "8:"
             "Transitive" = "11:FALSE"
             "Vital" = "11:TRUE"
@@ -6335,37 +5510,6 @@
             "IsDependency" = "11:FALSE"
             "IsolateTo" = "8:"
             }
-            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_AADD36F6B97F403495AEC87429288C87"
-            {
-            "AssemblyRegister" = "3:1"
-            "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:IKVM.AWT.WinForms, Version=8.1.5717.0, Culture=neutral, PublicKeyToken=13235d27fcbfff58, processorArchitecture=MSIL"
-                "ScatterAssemblies"
-                {
-                    "_AADD36F6B97F403495AEC87429288C87"
-                    {
-                    "Name" = "8:IKVM.AWT.WinForms.dll"
-                    "Attributes" = "3:512"
-                    }
-                }
-            "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x64\\IKVM.AWT.WinForms.dll"
-            "TargetName" = "8:"
-            "Tag" = "8:"
-            "Folder" = "8:_BE7C8A748AB042DFB3B17E4D4E332955"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
             "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_ACBB7A53E4154411A8736DB66962315C"
             {
             "AssemblyRegister" = "3:1"
@@ -6411,37 +5555,6 @@
                     }
                 }
             "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x64\\System.Runtime.Numerics.dll"
-            "TargetName" = "8:"
-            "Tag" = "8:"
-            "Folder" = "8:_BE7C8A748AB042DFB3B17E4D4E332955"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
-            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_B145E5EB173145D699545451BD2BAD93"
-            {
-            "AssemblyRegister" = "3:1"
-            "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:IKVM.OpenJDK.Localedata, Version=8.1.5717.0, Culture=neutral, PublicKeyToken=13235d27fcbfff58, processorArchitecture=MSIL"
-                "ScatterAssemblies"
-                {
-                    "_B145E5EB173145D699545451BD2BAD93"
-                    {
-                    "Name" = "8:IKVM.OpenJDK.Localedata.dll"
-                    "Attributes" = "3:512"
-                    }
-                }
-            "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x64\\IKVM.OpenJDK.Localedata.dll"
             "TargetName" = "8:"
             "Tag" = "8:"
             "Folder" = "8:_BE7C8A748AB042DFB3B17E4D4E332955"
@@ -6902,68 +6015,6 @@
             "IsDependency" = "11:FALSE"
             "IsolateTo" = "8:"
             }
-            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_C258DCC2A97441CC8D4CE99B30CCFE30"
-            {
-            "AssemblyRegister" = "3:1"
-            "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:IKVM.OpenJDK.XML.WebServices, Version=8.1.5717.0, Culture=neutral, PublicKeyToken=13235d27fcbfff58, processorArchitecture=MSIL"
-                "ScatterAssemblies"
-                {
-                    "_C258DCC2A97441CC8D4CE99B30CCFE30"
-                    {
-                    "Name" = "8:IKVM.OpenJDK.XML.WebServices.dll"
-                    "Attributes" = "3:512"
-                    }
-                }
-            "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x64\\IKVM.OpenJDK.XML.WebServices.dll"
-            "TargetName" = "8:"
-            "Tag" = "8:"
-            "Folder" = "8:_BE7C8A748AB042DFB3B17E4D4E332955"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
-            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_C2B6ECF719F84B17BE42A75B4AFC85FC"
-            {
-            "AssemblyRegister" = "3:1"
-            "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:IKVM.OpenJDK.Beans, Version=8.1.5717.0, Culture=neutral, PublicKeyToken=13235d27fcbfff58, processorArchitecture=MSIL"
-                "ScatterAssemblies"
-                {
-                    "_C2B6ECF719F84B17BE42A75B4AFC85FC"
-                    {
-                    "Name" = "8:IKVM.OpenJDK.Beans.dll"
-                    "Attributes" = "3:512"
-                    }
-                }
-            "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x64\\IKVM.OpenJDK.Beans.dll"
-            "TargetName" = "8:"
-            "Tag" = "8:"
-            "Folder" = "8:_BE7C8A748AB042DFB3B17E4D4E332955"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
             "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_C30DC62295394EAD816A84875FBC2873"
             {
             "AssemblyRegister" = "3:1"
@@ -7009,37 +6060,6 @@
                     }
                 }
             "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x64\\BouncyCastle.Crypto.dll"
-            "TargetName" = "8:"
-            "Tag" = "8:"
-            "Folder" = "8:_BE7C8A748AB042DFB3B17E4D4E332955"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
-            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_C74366375A7448EABFE460BBBC5E142A"
-            {
-            "AssemblyRegister" = "3:1"
-            "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:IKVM.OpenJDK.Misc, Version=8.1.5717.0, Culture=neutral, PublicKeyToken=13235d27fcbfff58, processorArchitecture=MSIL"
-                "ScatterAssemblies"
-                {
-                    "_C74366375A7448EABFE460BBBC5E142A"
-                    {
-                    "Name" = "8:IKVM.OpenJDK.Misc.dll"
-                    "Attributes" = "3:512"
-                    }
-                }
-            "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x64\\IKVM.OpenJDK.Misc.dll"
             "TargetName" = "8:"
             "Tag" = "8:"
             "Folder" = "8:_BE7C8A748AB042DFB3B17E4D4E332955"
@@ -7263,37 +6283,6 @@
             "IsDependency" = "11:FALSE"
             "IsolateTo" = "8:"
             }
-            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_CFA5745E6EEB4CD7A5170E2B8AA28D94"
-            {
-            "AssemblyRegister" = "3:1"
-            "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:IKVM.Runtime, Version=8.1.5717.0, Culture=neutral, PublicKeyToken=13235d27fcbfff58, processorArchitecture=MSIL"
-                "ScatterAssemblies"
-                {
-                    "_CFA5745E6EEB4CD7A5170E2B8AA28D94"
-                    {
-                    "Name" = "8:IKVM.Runtime.dll"
-                    "Attributes" = "3:512"
-                    }
-                }
-            "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x64\\IKVM.Runtime.dll"
-            "TargetName" = "8:"
-            "Tag" = "8:"
-            "Folder" = "8:_BE7C8A748AB042DFB3B17E4D4E332955"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
             "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_D1ADCB0D1B8243218A9C4E45BC47DB74"
             {
             "AssemblyRegister" = "3:1"
@@ -7308,37 +6297,6 @@
                     }
                 }
             "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x64\\System.Xml.XDocument.dll"
-            "TargetName" = "8:"
-            "Tag" = "8:"
-            "Folder" = "8:_BE7C8A748AB042DFB3B17E4D4E332955"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
-            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_D31E1D294B5D4340BD3E59D1E766383D"
-            {
-            "AssemblyRegister" = "3:1"
-            "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:IKVM.OpenJDK.XML.Bind, Version=8.1.5717.0, Culture=neutral, PublicKeyToken=13235d27fcbfff58, processorArchitecture=MSIL"
-                "ScatterAssemblies"
-                {
-                    "_D31E1D294B5D4340BD3E59D1E766383D"
-                    {
-                    "Name" = "8:IKVM.OpenJDK.XML.Bind.dll"
-                    "Attributes" = "3:512"
-                    }
-                }
-            "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x64\\IKVM.OpenJDK.XML.Bind.dll"
             "TargetName" = "8:"
             "Tag" = "8:"
             "Folder" = "8:_BE7C8A748AB042DFB3B17E4D4E332955"
@@ -7463,37 +6421,6 @@
                     }
                 }
             "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x64\\Microsoft.Extensions.Options.dll"
-            "TargetName" = "8:"
-            "Tag" = "8:"
-            "Folder" = "8:_BE7C8A748AB042DFB3B17E4D4E332955"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
-            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_D8510077E8014D0B95EABA90EA8C06A0"
-            {
-            "AssemblyRegister" = "3:1"
-            "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:IKVM.OpenJDK.Tools, Version=8.1.5717.0, Culture=neutral, PublicKeyToken=13235d27fcbfff58, processorArchitecture=MSIL"
-                "ScatterAssemblies"
-                {
-                    "_D8510077E8014D0B95EABA90EA8C06A0"
-                    {
-                    "Name" = "8:IKVM.OpenJDK.Tools.dll"
-                    "Attributes" = "3:512"
-                    }
-                }
-            "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x64\\IKVM.OpenJDK.Tools.dll"
             "TargetName" = "8:"
             "Tag" = "8:"
             "Folder" = "8:_BE7C8A748AB042DFB3B17E4D4E332955"
@@ -7728,37 +6655,6 @@
             "IsDependency" = "11:FALSE"
             "IsolateTo" = "8:"
             }
-            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_E2C042031A57431A9205FC9FCB561C49"
-            {
-            "AssemblyRegister" = "3:1"
-            "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:IKVM.OpenJDK.Util, Version=8.1.5717.0, Culture=neutral, PublicKeyToken=13235d27fcbfff58, processorArchitecture=MSIL"
-                "ScatterAssemblies"
-                {
-                    "_E2C042031A57431A9205FC9FCB561C49"
-                    {
-                    "Name" = "8:IKVM.OpenJDK.Util.dll"
-                    "Attributes" = "3:512"
-                    }
-                }
-            "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x64\\IKVM.OpenJDK.Util.dll"
-            "TargetName" = "8:"
-            "Tag" = "8:"
-            "Folder" = "8:_BE7C8A748AB042DFB3B17E4D4E332955"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
             "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_E71196F15A0F41C5B8CDB9293AE2E85A"
             {
             "AssemblyRegister" = "3:1"
@@ -7773,37 +6669,6 @@
                     }
                 }
             "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x64\\System.Threading.Tasks.Extensions.dll"
-            "TargetName" = "8:"
-            "Tag" = "8:"
-            "Folder" = "8:_BE7C8A748AB042DFB3B17E4D4E332955"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
-            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_E71C20ACF4664261A7ECB8759C724614"
-            {
-            "AssemblyRegister" = "3:1"
-            "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:IKVM.OpenJDK.XML.XPath, Version=8.1.5717.0, Culture=neutral, PublicKeyToken=13235d27fcbfff58, processorArchitecture=MSIL"
-                "ScatterAssemblies"
-                {
-                    "_E71C20ACF4664261A7ECB8759C724614"
-                    {
-                    "Name" = "8:IKVM.OpenJDK.XML.XPath.dll"
-                    "Attributes" = "3:512"
-                    }
-                }
-            "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x64\\IKVM.OpenJDK.XML.XPath.dll"
             "TargetName" = "8:"
             "Tag" = "8:"
             "Folder" = "8:_BE7C8A748AB042DFB3B17E4D4E332955"
@@ -7856,7 +6721,7 @@
             {
             "AssemblyRegister" = "3:1"
             "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:CloudVeil, Version=1.6.15.0, Culture=neutral, processorArchitecture=AMD64"
+            "AssemblyAsmDisplayName" = "8:CloudVeil, Version=1.6.17.0, Culture=neutral, processorArchitecture=AMD64"
                 "ScatterAssemblies"
                 {
                     "_E749BDE06CF0455CA7281BDB5F294DD9"
@@ -8286,37 +7151,6 @@
             "IsDependency" = "11:FALSE"
             "IsolateTo" = "8:"
             }
-            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_F319F875992947DB96A70712D6CF39D4"
-            {
-            "AssemblyRegister" = "3:1"
-            "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:IKVM.OpenJDK.Cldrdata, Version=8.1.5717.0, Culture=neutral, PublicKeyToken=13235d27fcbfff58, processorArchitecture=MSIL"
-                "ScatterAssemblies"
-                {
-                    "_F319F875992947DB96A70712D6CF39D4"
-                    {
-                    "Name" = "8:IKVM.OpenJDK.Cldrdata.dll"
-                    "Attributes" = "3:512"
-                    }
-                }
-            "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x64\\IKVM.OpenJDK.Cldrdata.dll"
-            "TargetName" = "8:"
-            "Tag" = "8:"
-            "Folder" = "8:_BE7C8A748AB042DFB3B17E4D4E332955"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
             "{1FB2D0AE-D3B9-43D4-B9DD-F88EC61E35DE}:_F40309BB4D594A64BC6D4A5C74C7DA3A"
             {
             "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x64\\GalaSoft.MvvmLight.Platform.pdb"
@@ -8351,37 +7185,6 @@
                     }
                 }
             "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x64\\Microsoft.AspNetCore.Diagnostics.dll"
-            "TargetName" = "8:"
-            "Tag" = "8:"
-            "Folder" = "8:_BE7C8A748AB042DFB3B17E4D4E332955"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
-            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_F4B1CF931C44450FB1E4876D3041921F"
-            {
-            "AssemblyRegister" = "3:1"
-            "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:IKVM.OpenJDK.Naming, Version=8.1.5717.0, Culture=neutral, PublicKeyToken=13235d27fcbfff58, processorArchitecture=MSIL"
-                "ScatterAssemblies"
-                {
-                    "_F4B1CF931C44450FB1E4876D3041921F"
-                    {
-                    "Name" = "8:IKVM.OpenJDK.Naming.dll"
-                    "Attributes" = "3:512"
-                    }
-                }
-            "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x64\\IKVM.OpenJDK.Naming.dll"
             "TargetName" = "8:"
             "Tag" = "8:"
             "Folder" = "8:_BE7C8A748AB042DFB3B17E4D4E332955"
@@ -8574,73 +7377,11 @@
             "IsDependency" = "11:FALSE"
             "IsolateTo" = "8:"
             }
-            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_FAEC8D5E7D7946D6B028D47DDEDA4E96"
-            {
-            "AssemblyRegister" = "3:1"
-            "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:IKVM.OpenJDK.Text, Version=8.1.5717.0, Culture=neutral, PublicKeyToken=13235d27fcbfff58, processorArchitecture=MSIL"
-                "ScatterAssemblies"
-                {
-                    "_FAEC8D5E7D7946D6B028D47DDEDA4E96"
-                    {
-                    "Name" = "8:IKVM.OpenJDK.Text.dll"
-                    "Attributes" = "3:512"
-                    }
-                }
-            "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x64\\IKVM.OpenJDK.Text.dll"
-            "TargetName" = "8:"
-            "Tag" = "8:"
-            "Folder" = "8:_BE7C8A748AB042DFB3B17E4D4E332955"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
-            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_FC8986371CB34FDE85D9F41E61CF301E"
-            {
-            "AssemblyRegister" = "3:1"
-            "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:IKVM.OpenJDK.Corba, Version=8.1.5717.0, Culture=neutral, PublicKeyToken=13235d27fcbfff58, processorArchitecture=MSIL"
-                "ScatterAssemblies"
-                {
-                    "_FC8986371CB34FDE85D9F41E61CF301E"
-                    {
-                    "Name" = "8:IKVM.OpenJDK.Corba.dll"
-                    "Attributes" = "3:512"
-                    }
-                }
-            "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x64\\IKVM.OpenJDK.Corba.dll"
-            "TargetName" = "8:"
-            "Tag" = "8:"
-            "Folder" = "8:_BE7C8A748AB042DFB3B17E4D4E332955"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
             "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_FD1AD3B6A959440DB8D217548E05ED75"
             {
             "AssemblyRegister" = "3:1"
             "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:Citadel.Core.Windows, Version=1.6.15.0, Culture=neutral, processorArchitecture=MSIL"
+            "AssemblyAsmDisplayName" = "8:Citadel.Core.Windows, Version=1.6.17.0, Culture=neutral, processorArchitecture=MSIL"
                 "ScatterAssemblies"
                 {
                     "_FD1AD3B6A959440DB8D217548E05ED75"
@@ -8650,37 +7391,6 @@
                     }
                 }
             "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x64\\Citadel.Core.Windows.dll"
-            "TargetName" = "8:"
-            "Tag" = "8:"
-            "Folder" = "8:_BE7C8A748AB042DFB3B17E4D4E332955"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
-            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_FDA28938341845008A82CE6C5CC78608"
-            {
-            "AssemblyRegister" = "3:1"
-            "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:IKVM.OpenJDK.XML.Crypto, Version=8.1.5717.0, Culture=neutral, PublicKeyToken=13235d27fcbfff58, processorArchitecture=MSIL"
-                "ScatterAssemblies"
-                {
-                    "_FDA28938341845008A82CE6C5CC78608"
-                    {
-                    "Name" = "8:IKVM.OpenJDK.XML.Crypto.dll"
-                    "Attributes" = "3:512"
-                    }
-                }
-            "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x64\\IKVM.OpenJDK.XML.Crypto.dll"
             "TargetName" = "8:"
             "Tag" = "8:"
             "Folder" = "8:_BE7C8A748AB042DFB3B17E4D4E332955"
@@ -8792,7 +7502,7 @@
         "Module"
         {
         "ModuleSignature" = "8:CloudVeilPayload.0862028596DF4668AB1D736D2B40424F"
-        "Version" = "8:1.6.16.0"
+        "Version" = "8:1.6.17.0"
         "Title" = "8:SetupPayload64"
         "Subject" = "8:"
         "Author" = "8:CloudVeil Technologies Inc."

--- a/Installers/SetupPayload86/SetupPayload86.vdproj
+++ b/Installers/SetupPayload86/SetupPayload86.vdproj
@@ -21,12 +21,6 @@
         }
         "Entry"
         {
-        "MsmKey" = "8:_00BEA9713D8F926AF674FE0710E9A011"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
         "MsmKey" = "8:_01661A78E81544059D0EF7568F1951B0"
         "OwnerKey" = "8:_UNDEFINED"
         "MsmSig" = "8:_UNDEFINED"
@@ -34,12 +28,6 @@
         "Entry"
         {
         "MsmKey" = "8:_02F017B95E894E3BB3061C5041379C80"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_036A10B2F4F8446396374D4A43A015DE"
         "OwnerKey" = "8:_UNDEFINED"
         "MsmSig" = "8:_UNDEFINED"
         }
@@ -58,12 +46,6 @@
         "Entry"
         {
         "MsmKey" = "8:_063B25436FD949B3A17CCA6A028B33DF"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_06894EAFDE5044F99D44A1A63EC73803"
         "OwnerKey" = "8:_UNDEFINED"
         "MsmSig" = "8:_UNDEFINED"
         }
@@ -88,12 +70,6 @@
         "Entry"
         {
         "MsmKey" = "8:_0976BCDE82FB4A068BC69755A4C9DEB6"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_09AEB2E2F5F54101AED7BA81C89EB8BD"
         "OwnerKey" = "8:_UNDEFINED"
         "MsmSig" = "8:_UNDEFINED"
         }
@@ -213,12 +189,6 @@
         }
         "Entry"
         {
-        "MsmKey" = "8:_1AE752308B5843B1A1C1ACAFE2EE8717"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
         "MsmKey" = "8:_1B0132816FF84EC487F6DA45C80FFCC3"
         "OwnerKey" = "8:_UNDEFINED"
         "MsmSig" = "8:_UNDEFINED"
@@ -251,6 +221,12 @@
         {
         "MsmKey" = "8:_21B31F7DB58346E9A524AC203DDDBBE0"
         "OwnerKey" = "8:_UNDEFINED"
+        "MsmSig" = "8:_UNDEFINED"
+        }
+        "Entry"
+        {
+        "MsmKey" = "8:_22C816D05B47073D3854DA9204AD0155"
+        "OwnerKey" = "8:_3F1B221A7A6249ACAB13AF3BE0162787"
         "MsmSig" = "8:_UNDEFINED"
         }
         "Entry"
@@ -399,12 +375,6 @@
         }
         "Entry"
         {
-        "MsmKey" = "8:_43EAB630741A42F4AE996108E4118EE6"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
         "MsmKey" = "8:_44F61AD0682549DC8CD56BC018049A41"
         "OwnerKey" = "8:_UNDEFINED"
         "MsmSig" = "8:_UNDEFINED"
@@ -471,30 +441,6 @@
         }
         "Entry"
         {
-        "MsmKey" = "8:_504A860032BF411FAD81262B7E28F9DD"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_53EFD2DECF8B40E2BB6CF4BCCB6688BE"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_53FEAD55559945F59ADD027804DC10D1"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_554CEF6F3EE749E7AD153E33FFCFA842"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
         "MsmKey" = "8:_5575A8F8F46F4F38980DD7D4B89922E0"
         "OwnerKey" = "8:_UNDEFINED"
         "MsmSig" = "8:_UNDEFINED"
@@ -502,12 +448,6 @@
         "Entry"
         {
         "MsmKey" = "8:_582F74560F10433988C13109226E8B60"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_5B1DA42DB46745B5AD4BFCEAEF19C71C"
         "OwnerKey" = "8:_UNDEFINED"
         "MsmSig" = "8:_UNDEFINED"
         }
@@ -574,12 +514,6 @@
         "Entry"
         {
         "MsmKey" = "8:_6830332CE9844DCE8D540B1A93CD4F13"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_685AB38824E74D72BE8F321896C8A0D5"
         "OwnerKey" = "8:_UNDEFINED"
         "MsmSig" = "8:_UNDEFINED"
         }
@@ -669,12 +603,6 @@
         }
         "Entry"
         {
-        "MsmKey" = "8:_7E138086B58E4D6D99F88219BCCC82A3"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
         "MsmKey" = "8:_7F5BB2C9309A40A9A94216ADBFC3BF13"
         "OwnerKey" = "8:_UNDEFINED"
         "MsmSig" = "8:_UNDEFINED"
@@ -723,12 +651,6 @@
         }
         "Entry"
         {
-        "MsmKey" = "8:_86DC139F541B45B897E2FDB7CFA4D039"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
         "MsmKey" = "8:_87394B0EDEF846B0921C1FFCE0F0EAB1"
         "OwnerKey" = "8:_UNDEFINED"
         "MsmSig" = "8:_UNDEFINED"
@@ -753,19 +675,7 @@
         }
         "Entry"
         {
-        "MsmKey" = "8:_8B01F95B275B400585FA96F846BE6DE5"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
         "MsmKey" = "8:_8CB81D30426B4098BC8D7BF89DFECB86"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_8CD6855B20004E5A869D5483C491493E"
         "OwnerKey" = "8:_UNDEFINED"
         "MsmSig" = "8:_UNDEFINED"
         }
@@ -796,12 +706,6 @@
         "Entry"
         {
         "MsmKey" = "8:_93990BACF199477D9167504D23FFEE91"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_94635D6407D74ABB97975368AE78FB2C"
         "OwnerKey" = "8:_UNDEFINED"
         "MsmSig" = "8:_UNDEFINED"
         }
@@ -861,25 +765,7 @@
         }
         "Entry"
         {
-        "MsmKey" = "8:_9B0FBC01BF8A4C4F983C755622112E5B"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_9D9DF977CC7F4E7E87133DD63DEDD201"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
         "MsmKey" = "8:_A14CBFE90604474EA66B6D9B6CA16C29"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_A3391743662F444B878C95E8DF8B1C3C"
         "OwnerKey" = "8:_UNDEFINED"
         "MsmSig" = "8:_UNDEFINED"
         }
@@ -904,12 +790,6 @@
         "Entry"
         {
         "MsmKey" = "8:_A6BE97A65191415083BFE7D082F3ED75"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_A74A4BD695F24F3AB321631E8F344E20"
         "OwnerKey" = "8:_UNDEFINED"
         "MsmSig" = "8:_UNDEFINED"
         }
@@ -993,12 +873,6 @@
         }
         "Entry"
         {
-        "MsmKey" = "8:_BB66A6EC7ADA44F7AF10FDA0EC73B8D9"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
         "MsmKey" = "8:_BBCA78CC701C478D977F430B724472A6"
         "OwnerKey" = "8:_UNDEFINED"
         "MsmSig" = "8:_UNDEFINED"
@@ -1006,12 +880,6 @@
         "Entry"
         {
         "MsmKey" = "8:_BDB62399A7AB493BBCC30E28759D41E6"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_BF96AD1B4B644C95B866A5DFE34DA745"
         "OwnerKey" = "8:_UNDEFINED"
         "MsmSig" = "8:_UNDEFINED"
         }
@@ -1030,12 +898,6 @@
         "Entry"
         {
         "MsmKey" = "8:_C3237655BFC842499CC39C557DC7FEB5"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_C4321F1C39E149AE90CD1FD0B85D1C11"
         "OwnerKey" = "8:_UNDEFINED"
         "MsmSig" = "8:_UNDEFINED"
         }
@@ -1113,12 +975,6 @@
         }
         "Entry"
         {
-        "MsmKey" = "8:_CED0297D625A4360AA42767C75EE7C18"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
         "MsmKey" = "8:_CF4BF4B9E5034165B95FB1E53B548988"
         "OwnerKey" = "8:_UNDEFINED"
         "MsmSig" = "8:_UNDEFINED"
@@ -1174,12 +1030,6 @@
         "Entry"
         {
         "MsmKey" = "8:_D96AFB1816534093A2616C573F66C8E2"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_D991585BB7224CB082D613AF498C0977"
         "OwnerKey" = "8:_UNDEFINED"
         "MsmSig" = "8:_UNDEFINED"
         }
@@ -1263,24 +1113,6 @@
         }
         "Entry"
         {
-        "MsmKey" = "8:_E4D5B57730EF440E8D7A963FF5EA7E25"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_E5C40EAEEC8C4FDF82F22294FBD02132"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_E797DD36EA14483C8C52D7C1F0560655"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
         "MsmKey" = "8:_E81ED0CC4E754B43A7A40F41900C8D0B"
         "OwnerKey" = "8:_UNDEFINED"
         "MsmSig" = "8:_UNDEFINED"
@@ -1306,12 +1138,6 @@
         "Entry"
         {
         "MsmKey" = "8:_EC22EB50572A411288488064E133C9C8"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_EDE3E1A69D5A45249FFBBF72F57779CC"
         "OwnerKey" = "8:_UNDEFINED"
         "MsmSig" = "8:_UNDEFINED"
         }
@@ -1359,12 +1185,6 @@
         }
         "Entry"
         {
-        "MsmKey" = "8:_F8D317DA2A894416B727157E511BD2CC"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
         "MsmKey" = "8:_FAB0448D11BD457DA5A435A256C6C38D"
         "OwnerKey" = "8:_UNDEFINED"
         "MsmSig" = "8:_UNDEFINED"
@@ -1384,43 +1204,19 @@
         "Entry"
         {
         "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_9D9DF977CC7F4E7E87133DD63DEDD201"
+        "OwnerKey" = "8:_9391778E8ECA43DCBE5E2685D59CFA59"
+        "MsmSig" = "8:_UNDEFINED"
+        }
+        "Entry"
+        {
+        "MsmKey" = "8:_UNDEFINED"
+        "OwnerKey" = "8:_3F1B221A7A6249ACAB13AF3BE0162787"
         "MsmSig" = "8:_UNDEFINED"
         }
         "Entry"
         {
         "MsmKey" = "8:_UNDEFINED"
         "OwnerKey" = "8:_8804DD287AC64626AE93C9705153814E"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_F8D317DA2A894416B727157E511BD2CC"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_EDE3E1A69D5A45249FFBBF72F57779CC"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_E797DD36EA14483C8C52D7C1F0560655"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_E5C40EAEEC8C4FDF82F22294FBD02132"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_E4D5B57730EF440E8D7A963FF5EA7E25"
         "MsmSig" = "8:_UNDEFINED"
         }
         "Entry"
@@ -1444,12 +1240,6 @@
         "Entry"
         {
         "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_D991585BB7224CB082D613AF498C0977"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_UNDEFINED"
         "OwnerKey" = "8:_D24C009CC01E4D5E94465B36D8BF0D96"
         "MsmSig" = "8:_UNDEFINED"
         }
@@ -1457,12 +1247,6 @@
         {
         "MsmKey" = "8:_UNDEFINED"
         "OwnerKey" = "8:_D22C30A44BFE48FAA667705372E6E3F9"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_CED0297D625A4360AA42767C75EE7C18"
         "MsmSig" = "8:_UNDEFINED"
         }
         "Entry"
@@ -1480,12 +1264,6 @@
         "Entry"
         {
         "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_C4321F1C39E149AE90CD1FD0B85D1C11"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_UNDEFINED"
         "OwnerKey" = "8:_C3237655BFC842499CC39C557DC7FEB5"
         "MsmSig" = "8:_UNDEFINED"
         }
@@ -1493,24 +1271,12 @@
         {
         "MsmKey" = "8:_UNDEFINED"
         "OwnerKey" = "8:_C3237655BFC842499CC39C557DC7FEB5"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_BF96AD1B4B644C95B866A5DFE34DA745"
         "MsmSig" = "8:_UNDEFINED"
         }
         "Entry"
         {
         "MsmKey" = "8:_UNDEFINED"
         "OwnerKey" = "8:_BBCA78CC701C478D977F430B724472A6"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_BB66A6EC7ADA44F7AF10FDA0EC73B8D9"
         "MsmSig" = "8:_UNDEFINED"
         }
         "Entry"
@@ -1558,19 +1324,7 @@
         "Entry"
         {
         "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_A74A4BD695F24F3AB321631E8F344E20"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_UNDEFINED"
         "OwnerKey" = "8:_A368CD272CB7462C9A99E497F501792F"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_A3391743662F444B878C95E8DF8B1C3C"
         "MsmSig" = "8:_UNDEFINED"
         }
         "Entry"
@@ -1582,49 +1336,13 @@
         "Entry"
         {
         "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_9B0FBC01BF8A4C4F983C755622112E5B"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_94635D6407D74ABB97975368AE78FB2C"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_9391778E8ECA43DCBE5E2685D59CFA59"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_UNDEFINED"
         "OwnerKey" = "8:_90227568FA99454589059712D601B033"
         "MsmSig" = "8:_UNDEFINED"
         }
         "Entry"
         {
         "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_8CD6855B20004E5A869D5483C491493E"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_UNDEFINED"
         "OwnerKey" = "8:_8CB81D30426B4098BC8D7BF89DFECB86"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_8B01F95B275B400585FA96F846BE6DE5"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_86DC139F541B45B897E2FDB7CFA4D039"
         "MsmSig" = "8:_UNDEFINED"
         }
         "Entry"
@@ -1642,19 +1360,7 @@
         "Entry"
         {
         "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_7E138086B58E4D6D99F88219BCCC82A3"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_UNDEFINED"
         "OwnerKey" = "8:_6C4AE007196B44C0B60FE94353DEFEA3"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_685AB38824E74D72BE8F321896C8A0D5"
         "MsmSig" = "8:_UNDEFINED"
         }
         "Entry"
@@ -1678,31 +1384,7 @@
         "Entry"
         {
         "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_5B1DA42DB46745B5AD4BFCEAEF19C71C"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_UNDEFINED"
         "OwnerKey" = "8:_582F74560F10433988C13109226E8B60"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_53FEAD55559945F59ADD027804DC10D1"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_53EFD2DECF8B40E2BB6CF4BCCB6688BE"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_504A860032BF411FAD81262B7E28F9DD"
         "MsmSig" = "8:_UNDEFINED"
         }
         "Entry"
@@ -1721,12 +1403,6 @@
         {
         "MsmKey" = "8:_UNDEFINED"
         "OwnerKey" = "8:_44F61AD0682549DC8CD56BC018049A41"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_43EAB630741A42F4AE996108E4118EE6"
         "MsmSig" = "8:_UNDEFINED"
         }
         "Entry"
@@ -1751,12 +1427,6 @@
         {
         "MsmKey" = "8:_UNDEFINED"
         "OwnerKey" = "8:_3F608FB4F7C548908F8F25149189A76D"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_3F1B221A7A6249ACAB13AF3BE0162787"
         "MsmSig" = "8:_UNDEFINED"
         }
         "Entry"
@@ -1792,12 +1462,6 @@
         "Entry"
         {
         "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_1AE752308B5843B1A1C1ACAFE2EE8717"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_UNDEFINED"
         "OwnerKey" = "8:_18ADB409D6CF4360B2BBBD51B3985685"
         "MsmSig" = "8:_UNDEFINED"
         }
@@ -1822,19 +1486,7 @@
         "Entry"
         {
         "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_09AEB2E2F5F54101AED7BA81C89EB8BD"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_UNDEFINED"
         "OwnerKey" = "8:_0976BCDE82FB4A068BC69755A4C9DEB6"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_06894EAFDE5044F99D44A1A63EC73803"
         "MsmSig" = "8:_UNDEFINED"
         }
         "Entry"
@@ -1847,12 +1499,6 @@
         {
         "MsmKey" = "8:_UNDEFINED"
         "OwnerKey" = "8:_0528E6FA64EE44C093FA793756776010"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_UNDEFINED"
-        "OwnerKey" = "8:_036A10B2F4F8446396374D4A43A015DE"
         "MsmSig" = "8:_UNDEFINED"
         }
         "Entry"
@@ -1985,32 +1631,6 @@
             "IsDependency" = "11:FALSE"
             "IsolateTo" = "8:"
             }
-            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_00BEA9713D8F926AF674FE0710E9A011"
-            {
-            "AssemblyRegister" = "3:1"
-            "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:System.Net.Http, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"
-                "ScatterAssemblies"
-                {
-                }
-            "SourcePath" = "8:System.Net.Http.dll"
-            "TargetName" = "8:"
-            "Tag" = "8:"
-            "Folder" = "8:_46E6D2F2ABA84935950C5B6504FA20EF"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:TRUE"
-            "IsolateTo" = "8:"
-            }
             "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_01661A78E81544059D0EF7568F1951B0"
             {
             "AssemblyRegister" = "3:1"
@@ -2056,37 +1676,6 @@
                     }
                 }
             "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x86\\System.Runtime.Numerics.dll"
-            "TargetName" = "8:"
-            "Tag" = "8:"
-            "Folder" = "8:_46E6D2F2ABA84935950C5B6504FA20EF"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
-            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_036A10B2F4F8446396374D4A43A015DE"
-            {
-            "AssemblyRegister" = "3:1"
-            "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:OpenNLP.IKVM, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL"
-                "ScatterAssemblies"
-                {
-                    "_036A10B2F4F8446396374D4A43A015DE"
-                    {
-                    "Name" = "8:OpenNLP.IKVM.dll"
-                    "Attributes" = "3:512"
-                    }
-                }
-            "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x86\\OpenNLP.IKVM.dll"
             "TargetName" = "8:"
             "Tag" = "8:"
             "Folder" = "8:_46E6D2F2ABA84935950C5B6504FA20EF"
@@ -2180,37 +1769,6 @@
                     }
                 }
             "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x86\\System.Runtime.Serialization.Json.dll"
-            "TargetName" = "8:"
-            "Tag" = "8:"
-            "Folder" = "8:_46E6D2F2ABA84935950C5B6504FA20EF"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
-            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_06894EAFDE5044F99D44A1A63EC73803"
-            {
-            "AssemblyRegister" = "3:1"
-            "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:IKVM.OpenJDK.Core, Version=8.1.5717.0, Culture=neutral, PublicKeyToken=13235d27fcbfff58, processorArchitecture=MSIL"
-                "ScatterAssemblies"
-                {
-                    "_06894EAFDE5044F99D44A1A63EC73803"
-                    {
-                    "Name" = "8:IKVM.OpenJDK.Core.dll"
-                    "Attributes" = "3:512"
-                    }
-                }
-            "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x86\\IKVM.OpenJDK.Core.dll"
             "TargetName" = "8:"
             "Tag" = "8:"
             "Folder" = "8:_46E6D2F2ABA84935950C5B6504FA20EF"
@@ -2335,37 +1893,6 @@
                     }
                 }
             "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x86\\WindowsFirewallHelper.dll"
-            "TargetName" = "8:"
-            "Tag" = "8:"
-            "Folder" = "8:_46E6D2F2ABA84935950C5B6504FA20EF"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
-            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_09AEB2E2F5F54101AED7BA81C89EB8BD"
-            {
-            "AssemblyRegister" = "3:1"
-            "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:IKVM.OpenJDK.Misc, Version=8.1.5717.0, Culture=neutral, PublicKeyToken=13235d27fcbfff58, processorArchitecture=MSIL"
-                "ScatterAssemblies"
-                {
-                    "_09AEB2E2F5F54101AED7BA81C89EB8BD"
-                    {
-                    "Name" = "8:IKVM.OpenJDK.Misc.dll"
-                    "Attributes" = "3:512"
-                    }
-                }
-            "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x86\\IKVM.OpenJDK.Misc.dll"
             "TargetName" = "8:"
             "Tag" = "8:"
             "Folder" = "8:_46E6D2F2ABA84935950C5B6504FA20EF"
@@ -2675,7 +2202,7 @@
             {
             "AssemblyRegister" = "3:1"
             "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:CitadelCore.Windows, Version=1.3.3.0, Culture=neutral, processorArchitecture=MSIL"
+            "AssemblyAsmDisplayName" = "8:CitadelCore.Windows, Version=1.3.4.0, Culture=neutral, processorArchitecture=MSIL"
                 "ScatterAssemblies"
                 {
                     "_13004E4988EB45418A4D6A5D3A74AA61"
@@ -2933,37 +2460,6 @@
                     }
                 }
             "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x86\\Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.dll"
-            "TargetName" = "8:"
-            "Tag" = "8:"
-            "Folder" = "8:_46E6D2F2ABA84935950C5B6504FA20EF"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
-            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_1AE752308B5843B1A1C1ACAFE2EE8717"
-            {
-            "AssemblyRegister" = "3:1"
-            "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:IKVM.OpenJDK.Cldrdata, Version=8.1.5717.0, Culture=neutral, PublicKeyToken=13235d27fcbfff58, processorArchitecture=MSIL"
-                "ScatterAssemblies"
-                {
-                    "_1AE752308B5843B1A1C1ACAFE2EE8717"
-                    {
-                    "Name" = "8:IKVM.OpenJDK.Cldrdata.dll"
-                    "Attributes" = "3:512"
-                    }
-                }
-            "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x86\\IKVM.OpenJDK.Cldrdata.dll"
             "TargetName" = "8:"
             "Tag" = "8:"
             "Folder" = "8:_46E6D2F2ABA84935950C5B6504FA20EF"
@@ -3767,7 +3263,7 @@
             {
             "AssemblyRegister" = "3:1"
             "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:FilterServiceProvider, Version=1.6.15.0, Culture=neutral, processorArchitecture=x86"
+            "AssemblyAsmDisplayName" = "8:FilterServiceProvider, Version=1.6.17.0, Culture=neutral, processorArchitecture=x86"
                 "ScatterAssemblies"
                 {
                     "_3F608FB4F7C548908F8F25149189A76D"
@@ -3870,37 +3366,6 @@
                     }
                 }
             "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x86\\System.Data.SQLite.EF6.dll"
-            "TargetName" = "8:"
-            "Tag" = "8:"
-            "Folder" = "8:_46E6D2F2ABA84935950C5B6504FA20EF"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
-            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_43EAB630741A42F4AE996108E4118EE6"
-            {
-            "AssemblyRegister" = "3:1"
-            "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:IKVM.Runtime.JNI, Version=8.1.5717.0, Culture=neutral, PublicKeyToken=13235d27fcbfff58, processorArchitecture=MSIL"
-                "ScatterAssemblies"
-                {
-                    "_43EAB630741A42F4AE996108E4118EE6"
-                    {
-                    "Name" = "8:IKVM.Runtime.JNI.dll"
-                    "Attributes" = "3:512"
-                    }
-                }
-            "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x86\\IKVM.Runtime.JNI.dll"
             "TargetName" = "8:"
             "Tag" = "8:"
             "Folder" = "8:_46E6D2F2ABA84935950C5B6504FA20EF"
@@ -4237,130 +3702,6 @@
             "IsDependency" = "11:FALSE"
             "IsolateTo" = "8:"
             }
-            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_504A860032BF411FAD81262B7E28F9DD"
-            {
-            "AssemblyRegister" = "3:1"
-            "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:IKVM.OpenJDK.Beans, Version=8.1.5717.0, Culture=neutral, PublicKeyToken=13235d27fcbfff58, processorArchitecture=MSIL"
-                "ScatterAssemblies"
-                {
-                    "_504A860032BF411FAD81262B7E28F9DD"
-                    {
-                    "Name" = "8:IKVM.OpenJDK.Beans.dll"
-                    "Attributes" = "3:512"
-                    }
-                }
-            "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x86\\IKVM.OpenJDK.Beans.dll"
-            "TargetName" = "8:"
-            "Tag" = "8:"
-            "Folder" = "8:_46E6D2F2ABA84935950C5B6504FA20EF"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
-            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_53EFD2DECF8B40E2BB6CF4BCCB6688BE"
-            {
-            "AssemblyRegister" = "3:1"
-            "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:IKVM.OpenJDK.XML.Transform, Version=8.1.5717.0, Culture=neutral, PublicKeyToken=13235d27fcbfff58, processorArchitecture=MSIL"
-                "ScatterAssemblies"
-                {
-                    "_53EFD2DECF8B40E2BB6CF4BCCB6688BE"
-                    {
-                    "Name" = "8:IKVM.OpenJDK.XML.Transform.dll"
-                    "Attributes" = "3:512"
-                    }
-                }
-            "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x86\\IKVM.OpenJDK.XML.Transform.dll"
-            "TargetName" = "8:"
-            "Tag" = "8:"
-            "Folder" = "8:_46E6D2F2ABA84935950C5B6504FA20EF"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
-            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_53FEAD55559945F59ADD027804DC10D1"
-            {
-            "AssemblyRegister" = "3:1"
-            "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:IKVM.OpenJDK.XML.API, Version=8.1.5717.0, Culture=neutral, PublicKeyToken=13235d27fcbfff58, processorArchitecture=MSIL"
-                "ScatterAssemblies"
-                {
-                    "_53FEAD55559945F59ADD027804DC10D1"
-                    {
-                    "Name" = "8:IKVM.OpenJDK.XML.API.dll"
-                    "Attributes" = "3:512"
-                    }
-                }
-            "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x86\\IKVM.OpenJDK.XML.API.dll"
-            "TargetName" = "8:"
-            "Tag" = "8:"
-            "Folder" = "8:_46E6D2F2ABA84935950C5B6504FA20EF"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
-            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_554CEF6F3EE749E7AD153E33FFCFA842"
-            {
-            "AssemblyRegister" = "3:1"
-            "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:ManagedWifi, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL"
-                "ScatterAssemblies"
-                {
-                    "_554CEF6F3EE749E7AD153E33FFCFA842"
-                    {
-                    "Name" = "8:ManagedWifi.dll"
-                    "Attributes" = "3:512"
-                    }
-                }
-            "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x86\\ManagedWifi.dll"
-            "TargetName" = "8:"
-            "Tag" = "8:"
-            "Folder" = "8:_46E6D2F2ABA84935950C5B6504FA20EF"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
             "{1FB2D0AE-D3B9-43D4-B9DD-F88EC61E35DE}:_5575A8F8F46F4F38980DD7D4B89922E0"
             {
             "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x86\\x86\\SQLite.Interop.dll"
@@ -4395,37 +3736,6 @@
                     }
                 }
             "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x86\\System.Runtime.Serialization.Primitives.dll"
-            "TargetName" = "8:"
-            "Tag" = "8:"
-            "Folder" = "8:_46E6D2F2ABA84935950C5B6504FA20EF"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
-            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_5B1DA42DB46745B5AD4BFCEAEF19C71C"
-            {
-            "AssemblyRegister" = "3:1"
-            "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:IKVM.OpenJDK.Corba, Version=8.1.5717.0, Culture=neutral, PublicKeyToken=13235d27fcbfff58, processorArchitecture=MSIL"
-                "ScatterAssemblies"
-                {
-                    "_5B1DA42DB46745B5AD4BFCEAEF19C71C"
-                    {
-                    "Name" = "8:IKVM.OpenJDK.Corba.dll"
-                    "Attributes" = "3:512"
-                    }
-                }
-            "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x86\\IKVM.OpenJDK.Corba.dll"
             "TargetName" = "8:"
             "Tag" = "8:"
             "Folder" = "8:_46E6D2F2ABA84935950C5B6504FA20EF"
@@ -4745,37 +4055,6 @@
                     }
                 }
             "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x86\\System.IO.UnmanagedMemoryStream.dll"
-            "TargetName" = "8:"
-            "Tag" = "8:"
-            "Folder" = "8:_46E6D2F2ABA84935950C5B6504FA20EF"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
-            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_685AB38824E74D72BE8F321896C8A0D5"
-            {
-            "AssemblyRegister" = "3:1"
-            "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:IKVM.OpenJDK.Remoting, Version=8.1.5717.0, Culture=neutral, PublicKeyToken=13235d27fcbfff58, processorArchitecture=MSIL"
-                "ScatterAssemblies"
-                {
-                    "_685AB38824E74D72BE8F321896C8A0D5"
-                    {
-                    "Name" = "8:IKVM.OpenJDK.Remoting.dll"
-                    "Attributes" = "3:512"
-                    }
-                }
-            "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x86\\IKVM.OpenJDK.Remoting.dll"
             "TargetName" = "8:"
             "Tag" = "8:"
             "Folder" = "8:_46E6D2F2ABA84935950C5B6504FA20EF"
@@ -5227,37 +4506,6 @@
             "IsDependency" = "11:FALSE"
             "IsolateTo" = "8:"
             }
-            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_7E138086B58E4D6D99F88219BCCC82A3"
-            {
-            "AssemblyRegister" = "3:1"
-            "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:IKVM.OpenJDK.Tools, Version=8.1.5717.0, Culture=neutral, PublicKeyToken=13235d27fcbfff58, processorArchitecture=MSIL"
-                "ScatterAssemblies"
-                {
-                    "_7E138086B58E4D6D99F88219BCCC82A3"
-                    {
-                    "Name" = "8:IKVM.OpenJDK.Tools.dll"
-                    "Attributes" = "3:512"
-                    }
-                }
-            "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x86\\IKVM.OpenJDK.Tools.dll"
-            "TargetName" = "8:"
-            "Tag" = "8:"
-            "Folder" = "8:_46E6D2F2ABA84935950C5B6504FA20EF"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
             "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_7F5BB2C9309A40A9A94216ADBFC3BF13"
             {
             "AssemblyRegister" = "3:1"
@@ -5495,37 +4743,6 @@
             "IsDependency" = "11:FALSE"
             "IsolateTo" = "8:"
             }
-            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_86DC139F541B45B897E2FDB7CFA4D039"
-            {
-            "AssemblyRegister" = "3:1"
-            "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:IKVM.OpenJDK.XML.Parse, Version=8.1.5717.0, Culture=neutral, PublicKeyToken=13235d27fcbfff58, processorArchitecture=MSIL"
-                "ScatterAssemblies"
-                {
-                    "_86DC139F541B45B897E2FDB7CFA4D039"
-                    {
-                    "Name" = "8:IKVM.OpenJDK.XML.Parse.dll"
-                    "Attributes" = "3:512"
-                    }
-                }
-            "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x86\\IKVM.OpenJDK.XML.Parse.dll"
-            "TargetName" = "8:"
-            "Tag" = "8:"
-            "Folder" = "8:_46E6D2F2ABA84935950C5B6504FA20EF"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
             "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_87394B0EDEF846B0921C1FFCE0F0EAB1"
             {
             "AssemblyRegister" = "3:1"
@@ -5619,37 +4836,6 @@
             "IsDependency" = "11:FALSE"
             "IsolateTo" = "8:"
             }
-            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_8B01F95B275B400585FA96F846BE6DE5"
-            {
-            "AssemblyRegister" = "3:1"
-            "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:IKVM.AWT.WinForms, Version=8.1.5717.0, Culture=neutral, PublicKeyToken=13235d27fcbfff58, processorArchitecture=MSIL"
-                "ScatterAssemblies"
-                {
-                    "_8B01F95B275B400585FA96F846BE6DE5"
-                    {
-                    "Name" = "8:IKVM.AWT.WinForms.dll"
-                    "Attributes" = "3:512"
-                    }
-                }
-            "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x86\\IKVM.AWT.WinForms.dll"
-            "TargetName" = "8:"
-            "Tag" = "8:"
-            "Folder" = "8:_46E6D2F2ABA84935950C5B6504FA20EF"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
             "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_8CB81D30426B4098BC8D7BF89DFECB86"
             {
             "AssemblyRegister" = "3:1"
@@ -5664,37 +4850,6 @@
                     }
                 }
             "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x86\\System.Runtime.Serialization.Xml.dll"
-            "TargetName" = "8:"
-            "Tag" = "8:"
-            "Folder" = "8:_46E6D2F2ABA84935950C5B6504FA20EF"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
-            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_8CD6855B20004E5A869D5483C491493E"
-            {
-            "AssemblyRegister" = "3:1"
-            "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:IKVM.OpenJDK.Management, Version=8.1.5717.0, Culture=neutral, PublicKeyToken=13235d27fcbfff58, processorArchitecture=MSIL"
-                "ScatterAssemblies"
-                {
-                    "_8CD6855B20004E5A869D5483C491493E"
-                    {
-                    "Name" = "8:IKVM.OpenJDK.Management.dll"
-                    "Attributes" = "3:512"
-                    }
-                }
-            "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x86\\IKVM.OpenJDK.Management.dll"
             "TargetName" = "8:"
             "Tag" = "8:"
             "Folder" = "8:_46E6D2F2ABA84935950C5B6504FA20EF"
@@ -5778,7 +4933,7 @@
             {
             "AssemblyRegister" = "3:1"
             "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:Citadel.IPC.Common, Version=1.6.15.0, Culture=neutral, processorArchitecture=MSIL"
+            "AssemblyAsmDisplayName" = "8:Citadel.IPC.Common, Version=1.6.17.0, Culture=neutral, processorArchitecture=MSIL"
                 "ScatterAssemblies"
                 {
                     "_90227568FA99454589059712D601B033"
@@ -5850,37 +5005,6 @@
                     }
                 }
             "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x86\\System.Threading.Tasks.Extensions.dll"
-            "TargetName" = "8:"
-            "Tag" = "8:"
-            "Folder" = "8:_46E6D2F2ABA84935950C5B6504FA20EF"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
-            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_94635D6407D74ABB97975368AE78FB2C"
-            {
-            "AssemblyRegister" = "3:1"
-            "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:IKVM.OpenJDK.Naming, Version=8.1.5717.0, Culture=neutral, PublicKeyToken=13235d27fcbfff58, processorArchitecture=MSIL"
-                "ScatterAssemblies"
-                {
-                    "_94635D6407D74ABB97975368AE78FB2C"
-                    {
-                    "Name" = "8:IKVM.OpenJDK.Naming.dll"
-                    "Attributes" = "3:512"
-                    }
-                }
-            "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x86\\IKVM.OpenJDK.Naming.dll"
             "TargetName" = "8:"
             "Tag" = "8:"
             "Folder" = "8:_46E6D2F2ABA84935950C5B6504FA20EF"
@@ -6166,73 +5290,11 @@
             "IsDependency" = "11:FALSE"
             "IsolateTo" = "8:"
             }
-            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_9B0FBC01BF8A4C4F983C755622112E5B"
-            {
-            "AssemblyRegister" = "3:1"
-            "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:IKVM.OpenJDK.XML.WebServices, Version=8.1.5717.0, Culture=neutral, PublicKeyToken=13235d27fcbfff58, processorArchitecture=MSIL"
-                "ScatterAssemblies"
-                {
-                    "_9B0FBC01BF8A4C4F983C755622112E5B"
-                    {
-                    "Name" = "8:IKVM.OpenJDK.XML.WebServices.dll"
-                    "Attributes" = "3:512"
-                    }
-                }
-            "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x86\\IKVM.OpenJDK.XML.WebServices.dll"
-            "TargetName" = "8:"
-            "Tag" = "8:"
-            "Folder" = "8:_46E6D2F2ABA84935950C5B6504FA20EF"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
-            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_9D9DF977CC7F4E7E87133DD63DEDD201"
-            {
-            "AssemblyRegister" = "3:1"
-            "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:IKVM.OpenJDK.Security, Version=8.1.5717.0, Culture=neutral, PublicKeyToken=13235d27fcbfff58, processorArchitecture=MSIL"
-                "ScatterAssemblies"
-                {
-                    "_9D9DF977CC7F4E7E87133DD63DEDD201"
-                    {
-                    "Name" = "8:IKVM.OpenJDK.Security.dll"
-                    "Attributes" = "3:512"
-                    }
-                }
-            "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x86\\IKVM.OpenJDK.Security.dll"
-            "TargetName" = "8:"
-            "Tag" = "8:"
-            "Folder" = "8:_46E6D2F2ABA84935950C5B6504FA20EF"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
             "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_A14CBFE90604474EA66B6D9B6CA16C29"
             {
             "AssemblyRegister" = "3:1"
             "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:CloudVeil, Version=1.6.15.0, Culture=neutral, processorArchitecture=x86"
+            "AssemblyAsmDisplayName" = "8:CloudVeil, Version=1.6.17.0, Culture=neutral, processorArchitecture=x86"
                 "ScatterAssemblies"
                 {
                     "_A14CBFE90604474EA66B6D9B6CA16C29"
@@ -6242,37 +5304,6 @@
                     }
                 }
             "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x86\\CloudVeil.exe"
-            "TargetName" = "8:"
-            "Tag" = "8:"
-            "Folder" = "8:_46E6D2F2ABA84935950C5B6504FA20EF"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
-            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_A3391743662F444B878C95E8DF8B1C3C"
-            {
-            "AssemblyRegister" = "3:1"
-            "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:IKVM.OpenJDK.Nashorn, Version=8.1.5717.0, Culture=neutral, PublicKeyToken=13235d27fcbfff58, processorArchitecture=MSIL"
-                "ScatterAssemblies"
-                {
-                    "_A3391743662F444B878C95E8DF8B1C3C"
-                    {
-                    "Name" = "8:IKVM.OpenJDK.Nashorn.dll"
-                    "Attributes" = "3:512"
-                    }
-                }
-            "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x86\\IKVM.OpenJDK.Nashorn.dll"
             "TargetName" = "8:"
             "Tag" = "8:"
             "Folder" = "8:_46E6D2F2ABA84935950C5B6504FA20EF"
@@ -6397,37 +5428,6 @@
                     }
                 }
             "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x86\\System.Runtime.InteropServices.dll"
-            "TargetName" = "8:"
-            "Tag" = "8:"
-            "Folder" = "8:_46E6D2F2ABA84935950C5B6504FA20EF"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
-            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_A74A4BD695F24F3AB321631E8F344E20"
-            {
-            "AssemblyRegister" = "3:1"
-            "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:IKVM.OpenJDK.Charsets, Version=8.1.5717.0, Culture=neutral, PublicKeyToken=13235d27fcbfff58, processorArchitecture=MSIL"
-                "ScatterAssemblies"
-                {
-                    "_A74A4BD695F24F3AB321631E8F344E20"
-                    {
-                    "Name" = "8:IKVM.OpenJDK.Charsets.dll"
-                    "Attributes" = "3:512"
-                    }
-                }
-            "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x86\\IKVM.OpenJDK.Charsets.dll"
             "TargetName" = "8:"
             "Tag" = "8:"
             "Folder" = "8:_46E6D2F2ABA84935950C5B6504FA20EF"
@@ -6826,37 +5826,6 @@
             "IsDependency" = "11:FALSE"
             "IsolateTo" = "8:"
             }
-            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_BB66A6EC7ADA44F7AF10FDA0EC73B8D9"
-            {
-            "AssemblyRegister" = "3:1"
-            "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:IKVM.OpenJDK.Media, Version=8.1.5717.0, Culture=neutral, PublicKeyToken=13235d27fcbfff58, processorArchitecture=MSIL"
-                "ScatterAssemblies"
-                {
-                    "_BB66A6EC7ADA44F7AF10FDA0EC73B8D9"
-                    {
-                    "Name" = "8:IKVM.OpenJDK.Media.dll"
-                    "Attributes" = "3:512"
-                    }
-                }
-            "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x86\\IKVM.OpenJDK.Media.dll"
-            "TargetName" = "8:"
-            "Tag" = "8:"
-            "Folder" = "8:_46E6D2F2ABA84935950C5B6504FA20EF"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
             "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_BBCA78CC701C478D977F430B724472A6"
             {
             "AssemblyRegister" = "3:1"
@@ -6902,37 +5871,6 @@
                     }
                 }
             "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x86\\System.Diagnostics.Debug.dll"
-            "TargetName" = "8:"
-            "Tag" = "8:"
-            "Folder" = "8:_46E6D2F2ABA84935950C5B6504FA20EF"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
-            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_BF96AD1B4B644C95B866A5DFE34DA745"
-            {
-            "AssemblyRegister" = "3:1"
-            "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:IKVM.Runtime, Version=8.1.5717.0, Culture=neutral, PublicKeyToken=13235d27fcbfff58, processorArchitecture=MSIL"
-                "ScatterAssemblies"
-                {
-                    "_BF96AD1B4B644C95B866A5DFE34DA745"
-                    {
-                    "Name" = "8:IKVM.Runtime.dll"
-                    "Attributes" = "3:512"
-                    }
-                }
-            "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x86\\IKVM.Runtime.dll"
             "TargetName" = "8:"
             "Tag" = "8:"
             "Folder" = "8:_46E6D2F2ABA84935950C5B6504FA20EF"
@@ -7016,7 +5954,7 @@
             {
             "AssemblyRegister" = "3:1"
             "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:Citadel.Core.Windows, Version=1.6.15.0, Culture=neutral, processorArchitecture=MSIL"
+            "AssemblyAsmDisplayName" = "8:Citadel.Core.Windows, Version=1.6.17.0, Culture=neutral, processorArchitecture=MSIL"
                 "ScatterAssemblies"
                 {
                     "_C3237655BFC842499CC39C557DC7FEB5"
@@ -7026,37 +5964,6 @@
                     }
                 }
             "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x86\\Citadel.Core.Windows.dll"
-            "TargetName" = "8:"
-            "Tag" = "8:"
-            "Folder" = "8:_46E6D2F2ABA84935950C5B6504FA20EF"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
-            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_C4321F1C39E149AE90CD1FD0B85D1C11"
-            {
-            "AssemblyRegister" = "3:1"
-            "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:IKVM.OpenJDK.Util, Version=8.1.5717.0, Culture=neutral, PublicKeyToken=13235d27fcbfff58, processorArchitecture=MSIL"
-                "ScatterAssemblies"
-                {
-                    "_C4321F1C39E149AE90CD1FD0B85D1C11"
-                    {
-                    "Name" = "8:IKVM.OpenJDK.Util.dll"
-                    "Attributes" = "3:512"
-                    }
-                }
-            "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x86\\IKVM.OpenJDK.Util.dll"
             "TargetName" = "8:"
             "Tag" = "8:"
             "Folder" = "8:_46E6D2F2ABA84935950C5B6504FA20EF"
@@ -7446,37 +6353,6 @@
             "IsDependency" = "11:FALSE"
             "IsolateTo" = "8:"
             }
-            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_CED0297D625A4360AA42767C75EE7C18"
-            {
-            "AssemblyRegister" = "3:1"
-            "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:IKVM.OpenJDK.Localedata, Version=8.1.5717.0, Culture=neutral, PublicKeyToken=13235d27fcbfff58, processorArchitecture=MSIL"
-                "ScatterAssemblies"
-                {
-                    "_CED0297D625A4360AA42767C75EE7C18"
-                    {
-                    "Name" = "8:IKVM.OpenJDK.Localedata.dll"
-                    "Attributes" = "3:512"
-                    }
-                }
-            "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x86\\IKVM.OpenJDK.Localedata.dll"
-            "TargetName" = "8:"
-            "Tag" = "8:"
-            "Folder" = "8:_46E6D2F2ABA84935950C5B6504FA20EF"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
             "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_CF4BF4B9E5034165B95FB1E53B548988"
             {
             "AssemblyRegister" = "3:1"
@@ -7749,37 +6625,6 @@
             {
             "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x86\\NLog.config"
             "TargetName" = "8:NLog.config"
-            "Tag" = "8:"
-            "Folder" = "8:_46E6D2F2ABA84935950C5B6504FA20EF"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
-            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_D991585BB7224CB082D613AF498C0977"
-            {
-            "AssemblyRegister" = "3:1"
-            "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:IKVM.OpenJDK.Text, Version=8.1.5717.0, Culture=neutral, PublicKeyToken=13235d27fcbfff58, processorArchitecture=MSIL"
-                "ScatterAssemblies"
-                {
-                    "_D991585BB7224CB082D613AF498C0977"
-                    {
-                    "Name" = "8:IKVM.OpenJDK.Text.dll"
-                    "Attributes" = "3:512"
-                    }
-                }
-            "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x86\\IKVM.OpenJDK.Text.dll"
-            "TargetName" = "8:"
             "Tag" = "8:"
             "Folder" = "8:_46E6D2F2ABA84935950C5B6504FA20EF"
             "Condition" = "8:"
@@ -8130,7 +6975,7 @@
             {
             "AssemblyRegister" = "3:1"
             "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:DistillNET, Version=1.4.4.0, Culture=neutral, processorArchitecture=MSIL"
+            "AssemblyAsmDisplayName" = "8:DistillNET, Version=1.4.5.0, Culture=neutral, processorArchitecture=MSIL"
                 "ScatterAssemblies"
                 {
                     "_E25B7A9F75064FE6904AA3A2D1854626"
@@ -8163,99 +7008,6 @@
             "TargetName" = "8:WinDivert64.sys"
             "Tag" = "8:"
             "Folder" = "8:_E2D27EA04AB94951B24C1F4C4D814612"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
-            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_E4D5B57730EF440E8D7A963FF5EA7E25"
-            {
-            "AssemblyRegister" = "3:1"
-            "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:IKVM.OpenJDK.Jdbc, Version=8.1.5717.0, Culture=neutral, PublicKeyToken=13235d27fcbfff58, processorArchitecture=MSIL"
-                "ScatterAssemblies"
-                {
-                    "_E4D5B57730EF440E8D7A963FF5EA7E25"
-                    {
-                    "Name" = "8:IKVM.OpenJDK.Jdbc.dll"
-                    "Attributes" = "3:512"
-                    }
-                }
-            "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x86\\IKVM.OpenJDK.Jdbc.dll"
-            "TargetName" = "8:"
-            "Tag" = "8:"
-            "Folder" = "8:_46E6D2F2ABA84935950C5B6504FA20EF"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
-            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_E5C40EAEEC8C4FDF82F22294FBD02132"
-            {
-            "AssemblyRegister" = "3:1"
-            "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:IKVM.OpenJDK.XML.Crypto, Version=8.1.5717.0, Culture=neutral, PublicKeyToken=13235d27fcbfff58, processorArchitecture=MSIL"
-                "ScatterAssemblies"
-                {
-                    "_E5C40EAEEC8C4FDF82F22294FBD02132"
-                    {
-                    "Name" = "8:IKVM.OpenJDK.XML.Crypto.dll"
-                    "Attributes" = "3:512"
-                    }
-                }
-            "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x86\\IKVM.OpenJDK.XML.Crypto.dll"
-            "TargetName" = "8:"
-            "Tag" = "8:"
-            "Folder" = "8:_46E6D2F2ABA84935950C5B6504FA20EF"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
-            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_E797DD36EA14483C8C52D7C1F0560655"
-            {
-            "AssemblyRegister" = "3:1"
-            "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:IKVM.OpenJDK.XML.Bind, Version=8.1.5717.0, Culture=neutral, PublicKeyToken=13235d27fcbfff58, processorArchitecture=MSIL"
-                "ScatterAssemblies"
-                {
-                    "_E797DD36EA14483C8C52D7C1F0560655"
-                    {
-                    "Name" = "8:IKVM.OpenJDK.XML.Bind.dll"
-                    "Attributes" = "3:512"
-                    }
-                }
-            "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x86\\IKVM.OpenJDK.XML.Bind.dll"
-            "TargetName" = "8:"
-            "Tag" = "8:"
-            "Folder" = "8:_46E6D2F2ABA84935950C5B6504FA20EF"
             "Condition" = "8:"
             "Transitive" = "11:FALSE"
             "Vital" = "11:TRUE"
@@ -8408,37 +7160,6 @@
                     }
                 }
             "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x86\\System.IO.Compression.ZipFile.dll"
-            "TargetName" = "8:"
-            "Tag" = "8:"
-            "Folder" = "8:_46E6D2F2ABA84935950C5B6504FA20EF"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
-            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_EDE3E1A69D5A45249FFBBF72F57779CC"
-            {
-            "AssemblyRegister" = "3:1"
-            "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:IKVM.OpenJDK.XML.XPath, Version=8.1.5717.0, Culture=neutral, PublicKeyToken=13235d27fcbfff58, processorArchitecture=MSIL"
-                "ScatterAssemblies"
-                {
-                    "_EDE3E1A69D5A45249FFBBF72F57779CC"
-                    {
-                    "Name" = "8:IKVM.OpenJDK.XML.XPath.dll"
-                    "Attributes" = "3:512"
-                    }
-                }
-            "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x86\\IKVM.OpenJDK.XML.XPath.dll"
             "TargetName" = "8:"
             "Tag" = "8:"
             "Folder" = "8:_46E6D2F2ABA84935950C5B6504FA20EF"
@@ -8662,37 +7383,6 @@
             "IsDependency" = "11:FALSE"
             "IsolateTo" = "8:"
             }
-            "{9F6F8455-1EF1-4B85-886A-4223BCC8E7F7}:_F8D317DA2A894416B727157E511BD2CC"
-            {
-            "AssemblyRegister" = "3:1"
-            "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:IKVM.OpenJDK.SwingAWT, Version=8.1.5717.0, Culture=neutral, PublicKeyToken=13235d27fcbfff58, processorArchitecture=MSIL"
-                "ScatterAssemblies"
-                {
-                    "_F8D317DA2A894416B727157E511BD2CC"
-                    {
-                    "Name" = "8:IKVM.OpenJDK.SwingAWT.dll"
-                    "Attributes" = "3:512"
-                    }
-                }
-            "SourcePath" = "8:..\\..\\CitadelGUI\\bin\\Release x86\\IKVM.OpenJDK.SwingAWT.dll"
-            "TargetName" = "8:"
-            "Tag" = "8:"
-            "Folder" = "8:_46E6D2F2ABA84935950C5B6504FA20EF"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
             "{1FB2D0AE-D3B9-43D4-B9DD-F88EC61E35DE}:_FAB0448D11BD457DA5A435A256C6C38D"
             {
             "SourcePath" = "8:..\\..\\CitadelGUI\\appicon.ico"
@@ -8838,7 +7528,7 @@
         "Module"
         {
         "ModuleSignature" = "8:CloudVeilPayload.620CD2DC407F43B9916732C473EF22AC"
-        "Version" = "8:1.6.16.0"
+        "Version" = "8:1.6.17.0"
         "Title" = "8:SetupPayload86"
         "Subject" = "8:"
         "Author" = "8:CloudVeil Technologies Inc."


### PR DESCRIPTION
Removed NLP libs/IKVM.
Used preprocessor ifdefs to black out NLP code so it can easily be added back later, except via SharpNL, not IKVM.
Upgraded core engine to resolve an issue with QUIC blocking.
Upgrade DistillNET to a version that doesn't have a buggy constructor.
Bump version to 1.6.17